### PR TITLE
Add detail-page sparkline, CSV preview, and prev/next nav

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,9 @@ The Django site behind <https://openmv.net> — a dataset catalogue that lists, 
   - `about_dataset` — `/info/<slug>` — detail page.
   - `download_dataset` — `/file/<name>.<ext>` — increments a `Hit` row, then 302-redirects to the media URL of the matching `DataFile`. The actual bytes are served by the front-end web server (Apache), not by Django.
 - **Templates** (`datasetapp/templates/datasetapp/`):
-  - `base.html` — Bootstrap 3 layout, inline `<style>`, no static-file dependency.
+  - `base.html` — Bootstrap 3 layout, inline `<style>`, no static-file dependency. Loads ECharts (CDN) for the detail-page sparkline.
   - `all_datasets.html` — the list page.
-  - `dataset_info.html` — the detail page; pulls in MathJax for any LaTeX in descriptions.
+  - `dataset_info.html` — the detail page. Pulls in MathJax for any LaTeX in descriptions, renders a 365-day downloads sparkline (ECharts) below the download counter, an inline CSV preview table (first 10 rows) above the download block, and prev/next dataset links at the bottom.
 - **Custom template tag**: `datasetapp/templatetags/extra_tags.py` defines a `slice_string` filter used in templates to trim filenames.
 - **Admin**: registered in `datasetapp/admin.py` with `list_per_page = 2000` (deliberate — small dataset count).
 

--- a/datasetapp/templates/datasetapp/base.html
+++ b/datasetapp/templates/datasetapp/base.html
@@ -1,5 +1,6 @@
 <head>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css">
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
 <style>
 body {
     padding: 4px;

--- a/datasetapp/templates/datasetapp/dataset_info.html
+++ b/datasetapp/templates/datasetapp/dataset_info.html
@@ -42,12 +42,55 @@
         </tr>
     </table>
 </div>
+{% if preview_rows %}
+<div id="dataset-preview" style="clear: both; margin-top: 16px;">
+    <h4>Preview (first {{ preview_rows|length|add:"-1" }} rows)</h4>
+    <table class="table table-striped table-condensed">
+        <thead>
+            <tr>{% for cell in preview_rows.0 %}<th>{{ cell }}</th>{% endfor %}</tr>
+        </thead>
+        <tbody>
+            {% for row in preview_rows|slice:"1:" %}
+            <tr>{% for cell in row %}<td>{{ cell }}</td>{% endfor %}</tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endif %}
 <div id="dataset-download">
 
     <h4>Download</h4>
 
     <a href="/file/{{ dfile.link_to_file.name|slice_string:"15:" }}">{{ dfile.file_type }}</a>
     &nbsp;&nbsp;&nbsp;&nbsp; [{{num_hits}} download{{num_hits|pluralize}}]
+
+    {% if num_hits %}
+    <div id="downloads-sparkline" style="width: 220px; height: 50px; margin-top: 6px;"></div>
+    <script>
+    (function() {
+        var data = {{ download_series_json|safe }};
+        var chart = echarts.init(document.getElementById('downloads-sparkline'));
+        chart.setOption({
+            grid: {left: 0, right: 0, top: 4, bottom: 4},
+            xAxis: {type: 'category', show: false, data: data.map(function(d){return d[0];})},
+            yAxis: {type: 'value', show: false, min: 0},
+            tooltip: {
+                trigger: 'axis',
+                formatter: function(params) {
+                    var p = params[0];
+                    return p.name + '<br/>' + p.value + ' download' + (p.value === 1 ? '' : 's');
+                }
+            },
+            series: [{
+                type: 'line', data: data.map(function(d){return d[1];}),
+                showSymbol: false, smooth: false,
+                lineStyle: {width: 1.5, color: '#3E6D8E'},
+                areaStyle: {color: 'rgba(62,109,142,0.15)'}
+            }]
+        });
+    })();
+    </script>
+    {% endif %}
 
     <p>(Right-click link; choose "<i>Save Link As</i>")
 
@@ -60,5 +103,13 @@
 
 <script type="text/javascript"
     src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-<!-- Have a link to go to Next and Previous dataset -->
+
+<nav style="clear: both; margin-top: 24px; padding-top: 12px; border-top: 1px solid #DDDDDD;">
+    {% if prev_dataset %}
+        <span style="float: left;">&larr; <a href="/info/{{ prev_dataset.slug }}">{{ prev_dataset.name }}</a></span>
+    {% endif %}
+    {% if next_dataset %}
+        <span style="float: right;"><a href="/info/{{ next_dataset.slug }}">{{ next_dataset.name }}</a> &rarr;</span>
+    {% endif %}
+</nav>
 {% endblock %}

--- a/datasetapp/tests/test_views.py
+++ b/datasetapp/tests/test_views.py
@@ -7,6 +7,9 @@ They deliberately do NOT assert page content beyond status codes — the goal
 is a CI tripwire for accidental view-level breakage, not template coverage.
 """
 
+import json
+from unittest.mock import patch
+
 import pytest
 from django.urls import reverse
 
@@ -74,3 +77,87 @@ def test_download_known_file_returns_302_and_increments_hits(client, dataset, cs
     )
     assert response.status_code == 302
     assert Hit.objects.count() == before + 1
+
+
+def test_about_includes_prev_next_when_neighbours_exist(client, db):
+    for slug, name in [("a-set", "Alpha"), ("b-set", "Beta"), ("c-set", "Gamma")]:
+        ds = Dataset.objects.create(
+            name=name,
+            slug=slug,
+            description="d",
+            author_name="a",
+            usage_restrictions="None",
+            data_source="s",
+        )
+        DataFile.objects.create(
+            file_type="CSV", link_to_file=f"datasets/{slug}.csv", dataset=ds
+        )
+
+    response = client.get(reverse("datasetapp:dataset-about-a-dataset", args=["b-set"]))
+    body = response.content.decode()
+    assert response.status_code == 200
+    assert "/info/a-set" in body
+    assert "/info/c-set" in body
+
+    # Boundary datasets only have one neighbour link.
+    first = client.get(
+        reverse("datasetapp:dataset-about-a-dataset", args=["a-set"])
+    ).content.decode()
+    assert "/info/b-set" in first
+    assert "/info/c-set" not in first
+    last = client.get(
+        reverse("datasetapp:dataset-about-a-dataset", args=["c-set"])
+    ).content.decode()
+    assert "/info/b-set" in last
+    assert "/info/a-set" not in last
+
+
+def test_about_csv_preview_renders_when_csv_present(client, dataset, csv_file):
+    fake_rows = [["sepal", "petal"], ["5.1", "1.4"], ["4.9", "1.4"]]
+    with patch("datasetapp.views._csv_preview", return_value=fake_rows):
+        response = client.get(
+            reverse("datasetapp:dataset-about-a-dataset", args=[dataset.slug])
+        )
+    body = response.content.decode()
+    assert response.status_code == 200
+    assert "Preview (first 2 rows)" in body
+    assert "sepal" in body and "petal" in body
+    assert "5.1" in body and "4.9" in body
+
+
+def test_about_omits_preview_when_only_non_csv_files(client, db):
+    ds = Dataset.objects.create(
+        name="X",
+        slug="x",
+        description="d",
+        author_name="a",
+        usage_restrictions="None",
+        data_source="s",
+    )
+    DataFile.objects.create(file_type="MAT", link_to_file="datasets/x.mat", dataset=ds)
+    response = client.get(reverse("datasetapp:dataset-about-a-dataset", args=["x"]))
+    assert response.status_code == 200
+    assert "dataset-preview" not in response.content.decode()
+
+
+def test_about_includes_download_series_for_sparkline(client, dataset, csv_file):
+    Hit.objects.create(
+        UA_string="pytest",
+        IP_address="127.0.0.1",
+        dataset_hit=csv_file,
+        referrer="",
+    )
+    response = client.get(
+        reverse("datasetapp:dataset-about-a-dataset", args=[dataset.slug])
+    )
+    body = response.content.decode()
+    assert response.status_code == 200
+    assert "downloads-sparkline" in body
+    # Pull the JSON literal out of the inline script and verify shape.
+    marker = "var data = "
+    start = body.index(marker) + len(marker)
+    end = body.index(";", start)
+    series = json.loads(body[start:end])
+    assert len(series) == 365
+    assert all(len(point) == 2 for point in series)
+    assert sum(point[1] for point in series) == 1

--- a/datasetapp/views.py
+++ b/datasetapp/views.py
@@ -5,19 +5,26 @@
 Future enhancements
 -------------------
 Return better 404's
-Show the first 10 rows and K columns on the dataset
-Links to go the next and previous datasets
 
 """
+import csv
+import datetime
+import io
+import itertools
+import json
 import logging.handlers
 
 # Standard library imports
 import os
 
 # Django imports
+from django.core.cache import cache
+from django.db.models import Count
+from django.db.models.functions import TruncDate
 from django.http import HttpResponse, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import reverse as django_reverse
+from django.utils import timezone
 
 # Model imports
 from .models import DataFile, Dataset, Hit, Tag
@@ -85,6 +92,51 @@ def display_all(request):
     return TemplateResponse(request, "datasetapp/all_datasets.html", context)
 
 
+def _csv_preview(file_obj, max_rows=10, max_bytes=100 * 1024):
+    """First ``max_rows`` data rows of a CSV ``DataFile`` (header + rows), or None."""
+    if file_obj is None or file_obj.file_type.upper() != "CSV":
+        return None
+    cache_key = f"csv_preview:{file_obj.id}:{max_rows}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+    try:
+        with file_obj.link_to_file.open("rb") as fh:
+            raw = fh.read(max_bytes)
+        text = raw.decode("utf-8", errors="replace")
+        try:
+            dialect = csv.Sniffer().sniff(text[:2048], delimiters=",;\t")
+        except csv.Error:
+            dialect = csv.excel
+        reader = csv.reader(io.StringIO(text), dialect)
+        rows = list(itertools.islice(reader, max_rows + 1))
+    except Exception as e:
+        log_file.warning("CSV preview failed for DataFile %s: %s", file_obj.id, e)
+        rows = None
+    cache.set(cache_key, rows, 60 * 60)
+    return rows
+
+
+def _download_series(dataset, days=365):
+    """List of ``[yyyy-mm-dd, count]`` pairs for the last ``days`` days, zero-filled."""
+    today = timezone.now().date()
+    start = today - datetime.timedelta(days=days - 1)
+    counts = (
+        Hit.objects.filter(dataset_hit__dataset=dataset, date_and_time__date__gte=start)
+        .annotate(day=TruncDate("date_and_time"))
+        .values("day")
+        .annotate(n=Count("id"))
+    )
+    counts_by_day = {row["day"]: row["n"] for row in counts}
+    return [
+        [
+            (start + datetime.timedelta(days=i)).isoformat(),
+            counts_by_day.get(start + datetime.timedelta(days=i), 0),
+        ]
+        for i in range(days)
+    ]
+
+
 def about_dataset(request, dataset_name=None):
     """
     Displays more information about a dataset
@@ -97,11 +149,31 @@ def about_dataset(request, dataset_name=None):
         log_file.error("An invalid dataset was requested: %s", dataset_name.lower())
         return HttpResponseRedirect(django_reverse("datasetapp:dataset-home-page"))
 
-    files = DataFile.objects.filter(dataset=ds[0])
+    ds = ds[0]
+    files = DataFile.objects.filter(dataset=ds)
+
+    # Prev/next navigation: use the same slug ordering as the homepage table.
+    ordered_slugs = list(
+        Dataset.objects.order_by("slug").values_list("slug", flat=True)
+    )
+    idx = ordered_slugs.index(ds.slug)
+    prev_slug = ordered_slugs[idx - 1] if idx > 0 else None
+    next_slug = ordered_slugs[idx + 1] if idx < len(ordered_slugs) - 1 else None
+    prev_dataset = Dataset.objects.get(slug=prev_slug) if prev_slug else None
+    next_dataset = Dataset.objects.get(slug=next_slug) if next_slug else None
+
+    # CSV preview (skip when dataset is hidden, defence in depth).
+    csv_file = files.filter(file_type__iexact="CSV").first()
+    preview_rows = _csv_preview(csv_file) if not ds.is_hidden else None
+
     context = {
-        "ds": ds[0],
+        "ds": ds,
         "dfile": files[0],
         "num_hits": Hit.objects.filter(dataset_hit=files[0]).count(),
+        "prev_dataset": prev_dataset,
+        "next_dataset": next_dataset,
+        "preview_rows": preview_rows,
+        "download_series_json": json.dumps(_download_series(ds)),
     }
     return TemplateResponse(request, "datasetapp/dataset_info.html", context)
 


### PR DESCRIPTION
## Summary

Three additive front-end changes to the dataset detail page (`/info/<slug>`):

- **365-day downloads sparkline** (new) — small ECharts line+area chart below the `[N downloads]` counter; hovering shows the exact count and date in `yyyy-mm-dd`. Zero-filled across days with no downloads so the trend is honest. Suppressed when `num_hits == 0`. ECharts is loaded once from jsdelivr in `base.html`, matching the existing Bootstrap/MathJax CDN pattern.
- **Inline CSV preview** (closes #37) — first 10 rows of the CSV `DataFile` rendered as a Bootstrap table above the download block. `csv.Sniffer` detects `,`/`;`/tab; reads are capped at 100 KB; parse failures fall back to no preview. Cached per `DataFile.id` for an hour in Django's default cache. Skipped for hidden datasets and datasets that only have non-CSV files.
- **Prev/next dataset links** (closes #36) — small nav strip at the bottom of the page, ordered by slug to match the homepage table and `Dataset.Meta.ordering`. Hidden datasets are not filtered out, mirroring the homepage's current behaviour (per the long-standing `get_query_set` gotcha in `CLAUDE.md`).

Stale inline TODOs in `datasetapp/views.py` and `dataset_info.html` (referenced in both issues) are cleaned up. `CLAUDE.md` is updated to reflect the new template responsibilities.

## Test plan

- [x] `uv run pytest` — all 9 tests pass (5 existing + 4 new)
- [x] `uv run pre-commit run --all-files` — black, isort, flake8, mypy all green
- [ ] Manual smoke on a local `make debug` — load `/info/<slug>` and verify:
  - sparkline renders, tooltip shows `2026-04-15` + `N downloads`
  - CSV preview table appears for CSV-backed datasets, absent otherwise
  - prev/next links wrap correctly at the catalogue boundaries

https://claude.ai/code/session_01D6tXZxfd6GZGF5eiuuKyFy

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6tXZxfd6GZGF5eiuuKyFy)_