### PR TITLE
Auto-tag + GitHub Release on version bump (finishes #18)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+# Auto-tags and creates a GitHub Release whenever the version in
+# pyproject.toml changes on master and there is a matching `## v<version>`
+# section in RELEASES.md.
+#
+# To cut a new release: bump the `version` field in pyproject.toml in a PR,
+# add a `## v<new-version>` section at the top of RELEASES.md describing
+# the changes, and merge. This workflow does the rest.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - pyproject.toml
+      - RELEASES.md
+      - .github/workflows/release.yml
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from pyproject.toml
+        id: version
+        run: |
+          version=$(awk -F'"' '/^version = /{print $2; exit}' pyproject.toml)
+          if [ -z "$version" ]; then
+            echo "::error::Could not read version from pyproject.toml"
+            exit 1
+          fi
+          tag="v$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag"         >> "$GITHUB_OUTPUT"
+          echo "Detected version: $version (tag: $tag)"
+
+      - name: Skip if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.version.outputs.tag }}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release $tag already exists; nothing to do."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract release notes from RELEASES.md
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          tag="${{ steps.version.outputs.tag }}"
+          awk -v tag="$tag" '
+            $0 == "## " tag       { found = 1; next }
+            found && /^## v/      { exit }
+            found                 { print }
+          ' RELEASES.md > release_notes.md
+
+          # Trim leading/trailing blank lines.
+          sed -i -e '/./,$!d' -e :a -e '/^\s*$/{$d;N;ba' -e '}' release_notes.md
+
+          if [ ! -s release_notes.md ]; then
+            echo "::error::No '## $tag' section found in RELEASES.md. Add one and re-run."
+            exit 1
+          fi
+
+          echo "--- release notes for $tag ---"
+          cat release_notes.md
+          echo "--- end ---"
+
+      - name: Create tag and GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.version.outputs.tag }}"
+          gh release create "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "$tag" \
+            --notes-file release_notes.md


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` so future releases are fully automated. When `pyproject.toml`'s version changes on master, the workflow:

1. Reads the version from `pyproject.toml`.
2. Skips if a GitHub Release for `v<version>` already exists (idempotent — safe to re-run).
3. Extracts the matching `## v<version>` section from `RELEASES.md`.
4. Creates the git tag (pointing at the merged commit) and a GitHub Release using the extracted notes as the body.

**This PR's merge will produce the v1.0.0 tag and Release for `openmv`** — the path filter includes `.github/workflows/release.yml`, so adding the workflow itself triggers the first run, which finds `version = "1.0.0"` in `pyproject.toml` and the matching section in `RELEASES.md` (both landed in #39).

## Cutting future releases

Just two file edits in a normal PR; the workflow does the rest:

1. Bump `version = "1.0.0"` → `"1.1.0"` (or whatever) in `pyproject.toml`.
2. Prepend a `## v1.1.0` section to `RELEASES.md` describing the changes.
3. Merge to master.

If you forget the `RELEASES.md` section, the workflow fails loudly with `::error:: No '## v1.1.0' section found in RELEASES.md`.

## Why this design

- Version + notes are reviewed in the PR alongside the change itself, so the release body is always accurate.
- No extra tooling — uses `gh` (preinstalled on GitHub-hosted runners) and the built-in `GITHUB_TOKEN` with `contents: write` scoped to this job.
- `workflow_dispatch` fallback for manual re-runs.
- Idempotent: a re-merge or re-run on the same SHA short-circuits.

## Test plan

- [x] Locally dry-ran the version + notes extraction against the current files: detected `v1.0.0` and extracted the correct section from `RELEASES.md`.
- [x] `uv run pre-commit run --all-files` — all hooks pass (including `check yaml`).
- [ ] After merging this PR, confirm a `v1.0.0` tag and matching Release appear at <https://github.com/kgdunn/Django-dataset-download-app/releases/tag/v1.0.0>. I'll close #18 once verified.

https://claude.ai/code/session_01FpG8L7ZvUtKwXZhduPZ3sE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpG8L7ZvUtKwXZhduPZ3sE)_