### PR TITLE
Prepare for Hetzner deployment behind Caddy

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,58 @@
+# Production compose file for openmv.net on a multi-tenant VPS where Caddy
+# (host-installed) is the shared reverse proxy. Both services bind to
+# loopback only; Caddy is the sole public-facing process.
+#
+# Usage:
+#   docker compose -f docker-compose.prod.yml up -d --build
+#
+# Ports are offset from any other Compose stack on the same host:
+#   - openmv-app:      127.0.0.1:8001 -> 8000
+#   - openmv-postgres: 127.0.0.1:5434 -> 5432
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: openmv-postgres
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - openmv_postgres_data:/var/lib/postgresql/data
+    ports:
+      - "127.0.0.1:5434:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  web:
+    build: .
+    image: openmv-app:latest
+    container_name: openmv-app
+    env_file: .env
+    environment:
+      SQL_HOST: db
+      SQL_PORT: 5432
+    volumes:
+      - ./data/media:/app/media
+      - ./data/static:/app/static
+    ports:
+      - "127.0.0.1:8001:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+    command: >
+      sh -c "python manage.py migrate --noinput &&
+             python manage.py collectstatic --noinput &&
+             gunicorn openmv.wsgi:application
+                      --bind 0.0.0.0:8000
+                      --workers 3
+                      --access-logfile -
+                      --error-logfile -"
+
+volumes:
+  openmv_postgres_data:

--- a/openmv/settings.py
+++ b/openmv/settings.py
@@ -27,6 +27,18 @@ DEBUG = bool(int(dotenv_values(dotenv_path=dotenv_file).get("DJANGO_DEBUG", None
 
 ALLOWED_HOSTS = [".openmv.net", "127.0.0.1"]
 
+# Caddy terminates TLS on the host and proxies plain HTTP to gunicorn.
+# This header tells Django the request was originally HTTPS.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+# Required by Django 4.x for any non-GET request (e.g. admin login) when the
+# request reaches Django over HTTPS via a reverse proxy.
+CSRF_TRUSTED_ORIGINS = [
+    "https://openmv.net",
+    "https://www.openmv.net",
+    "https://test.openmv.net",
+]
+
 # Application definition
 INSTALLED_APPS = [
     "django.contrib.admin",


### PR DESCRIPTION
## Summary

Two minimal changes the Hetzner cutover needs before it can serve a real request:

- **`openmv/settings.py`** — adds `SECURE_PROXY_SSL_HEADER` (so Django sees `X-Forwarded-Proto: https` from Caddy correctly) and `CSRF_TRUSTED_ORIGINS` for the apex, `www`, and the temporary `test.openmv.net` hostname used during pre-cutover verification.
- **`docker-compose.prod.yml`** — production-side compose file that runs the existing `Dockerfile` image with gunicorn, binds both containers to loopback on offset ports (`127.0.0.1:8001` for the app, `127.0.0.1:5434` for Postgres) so it coexists cleanly with other Compose stacks on the same VPS, and bind-mounts `./data/media` and `./data/static`. The `web` command runs `migrate` + `collectstatic` on each start.

## Relationship to roadmap (issue #42)

- The CSRF / proxy settings are a **partial advance of #12** (security headers). The remaining items in #12 — HSTS, secure cookies, `X_FRAME_OPTIONS` — are intentionally **not** in this PR; per the roadmap they belong in batch C3 after C1 (settings split) and C2 (env-first) land. This PR only takes what the migration physically can't function without.
- `docker-compose.prod.yml` is a **deployment artifact**, not the CI-built image push of **F1 / #24**. It uses the existing local `Dockerfile`. F1's GHCR pipeline can replace `build: .` with `image: ghcr.io/...` when it lands, with no other changes.

## Test plan

- [ ] On Hetzner, clone this branch into `/home/deploy/openmv/`, write `.env` with prod values, `docker compose -f docker-compose.prod.yml up -d --build`.
- [ ] Confirm Postgres is healthy and gunicorn responds on `127.0.0.1:8001`.
- [ ] Add a Caddy site block for `test.openmv.net` proxying to `127.0.0.1:8001`; reload Caddy.
- [ ] Restore the production DB dump from Linode and rsync `/var/www/media`.
- [ ] Verify `https://test.openmv.net` renders the homepage, dataset detail pages render the CSV preview + sparkline, and a download redirect resolves to the rsynced media file.
- [ ] Confirm admin login works (validates `CSRF_TRUSTED_ORIGINS`).

https://claude.ai/code/session_0156oMTHWthdDv7cFxcHBaeV

---
_Generated by [Claude Code](https://claude.ai/code/session_0156oMTHWthdDv7cFxcHBaeV)_