### PR TITLE
Fix prod compose: bind-mount .env, fix command newline handling

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,6 +37,11 @@ services:
       SQL_HOST: db
       SQL_PORT: 5432
     volumes:
+      # openmv/settings.py reads the .env file at BASE_DIR / ".env" at import
+      # time (not just environment variables), so the file itself must be
+      # present in the container. .dockerignore excludes it from the image,
+      # so we bind-mount the host copy read-only.
+      - ./.env:/app/.env:ro
       - ./data/media:/app/media
       - ./data/static:/app/static
     ports:
@@ -45,14 +50,13 @@ services:
       db:
         condition: service_healthy
     restart: unless-stopped
-    command: >
-      sh -c "python manage.py migrate --noinput &&
-             python manage.py collectstatic --noinput &&
-             gunicorn openmv.wsgi:application
-                      --bind 0.0.0.0:8000
-                      --workers 3
-                      --access-logfile -
-                      --error-logfile -"
+    command:
+      - sh
+      - -c
+      - |
+        python manage.py migrate --noinput &&
+        python manage.py collectstatic --noinput &&
+        gunicorn openmv.wsgi:application --bind 0.0.0.0:8000 --workers 3 --access-logfile - --error-logfile -
 
 volumes:
   openmv_postgres_data:


### PR DESCRIPTION
## Summary

Two bugs surfaced when bringing the openmv stack up on Hetzner via `docker-compose.prod.yml`:

1. **`.env` wasn't in the container.** `openmv/settings.py` reads the file directly at `BASE_DIR/.env` at import time (not just env vars), and asserts it exists. But `.dockerignore` excludes it from the image, and `env_file:` in compose only loads its values as environment variables. Result: container crashed with `AssertionError: /app/.env does not exist`. Fixed by bind-mounting the host `.env` into `/app/.env` read-only.

2. **`command: >` preserved newlines on the gunicorn flag lines.** The folded scalar collapses lines at the same indent but preserves newlines on more-indented continuations, so `sh -c` saw `--bind 0.0.0.0:8000`, `--workers 3`, etc. as separate commands and exited 127 with `sh: 4: --bind: not found`. Fixed by switching to the YAML list form with a literal block scalar — the gunicorn invocation is now one explicit line and indentation no longer matters.

## Relationship to roadmap (#42)

The proper long-term fix for (1) is **C2 / #22** (env-first config, drop the `.env` assert). This PR doesn't anticipate that batch — it's the minimum needed to unblock the in-flight Hetzner migration. When C2 lands, the `.env` bind-mount can stay (still useful for local dev) or be removed.

(2) is a pure compose-file bug, no roadmap connection.

## Test plan

- [ ] On Hetzner, `git pull && docker compose -f docker-compose.prod.yml up -d --build`
- [ ] `docker compose -f docker-compose.prod.yml ps` shows both services `Up` with web `(healthy)`-ish (no healthcheck defined yet, just running)
- [ ] `docker compose -f docker-compose.prod.yml logs web` shows: migrate ran, collectstatic ran, gunicorn started listening on 0.0.0.0:8000
- [ ] `curl -sI http://127.0.0.1:8001/` returns an HTTP response

https://claude.ai/code/session_0156oMTHWthdDv7cFxcHBaeV

---
_Generated by [Claude Code](https://claude.ai/code/session_0156oMTHWthdDv7cFxcHBaeV)_