### PR TITLE
Make /app writable by the runtime user in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,12 @@ WORKDIR /app
 COPY --from=builder /app/.venv /app/.venv
 COPY --chown=app:app . .
 
+# WORKDIR created /app as root-owned. The COPY --chown above sets ownership
+# on the copied contents, but not on /app itself. Make the working directory
+# writable by the runtime user so the app can create files like logfile.log
+# (datasetapp/views.py opens this at import time via RotatingFileHandler).
+RUN chown app:app /app
+
 ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary

`WORKDIR /app` creates `/app` before any `COPY` runs, so the directory itself is owned by root. `COPY --chown=app:app . .` only sets ownership on the copied contents, not on the directory. Result: the runtime user (`app`, UID 1000) can read/execute under `/app` but can't create new files directly there.

This surfaced when starting the container on Hetzner: `datasetapp/views.py` opens `<repo>/logfile.log` at module-import time via `RotatingFileHandler`, which crashed with:

```
PermissionError: [Errno 13] Permission denied: '/app/logfile.log'
```

One-line fix: `RUN chown app:app /app` after the COPYs, before `USER app`.

## Relationship to roadmap (#42)

The proper long-term fix is **#15** — replace the import-time `RotatingFileHandler` with a `LOGGING` dict pointing at stdout/stderr (let Docker handle log capture). That's batch C3 work, sequenced after C1 (settings split) per the roadmap. This Dockerfile change is the minimum needed to unblock the in-flight Hetzner migration without anticipating that batch.

## Test plan

- [ ] On Hetzner: `git pull && docker compose -f docker-compose.prod.yml up -d --build`
- [ ] `docker compose -f docker-compose.prod.yml logs web` shows `migrate` ran, `collectstatic` ran, gunicorn started — no `PermissionError`
- [ ] `curl -sI http://127.0.0.1:8001/` returns an HTTP 200

https://claude.ai/code/session_0156oMTHWthdDv7cFxcHBaeV

---
_Generated by [Claude Code](https://claude.ai/code/session_0156oMTHWthdDv7cFxcHBaeV)_