### PR TITLE
Auto-deploy to Hetzner on push to master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+# Auto-deploy openmv to the Hetzner production host on every push to master.
+#
+# How it works:
+#   - The job opens an SSH session to the deploy user on Hetzner using a key
+#     stored in the HETZNER_SSH_KEY repository secret.
+#   - That key's entry in the host's authorized_keys uses a forced command,
+#     so the only thing the SSH session can do is run a fixed wrapper script
+#     (~/openmv/bin/deploy.sh on the host). Whatever this workflow puts after
+#     `ssh user@host` is ignored by the server.
+#   - The wrapper fast-forwards the repo to origin/master, then exec's
+#     bin/deploy-impl.sh from the freshly-pulled tree — that's the file you
+#     edit when you want to change deploy behaviour.
+#
+# A leaked HETZNER_SSH_KEY can therefore only trigger the deploy script;
+# it cannot open a shell, run docker commands directly, or read other apps
+# on the same VPS.
+
+name: Deploy to Hetzner
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-hetzner
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: SSH and trigger deploy
+        env:
+          SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+          HOST: ${{ secrets.HETZNER_HOST }}
+          USERNAME: ${{ secrets.HETZNER_USER }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          # The remote SSH server will ignore any command we pass and run
+          # the forced command from authorized_keys (~/openmv/bin/deploy.sh).
+          ssh -i ~/.ssh/deploy_key \
+              -o ServerAliveInterval=15 \
+              -o ServerAliveCountMax=20 \
+              "$USERNAME@$HOST"

--- a/bin/deploy-impl.sh
+++ b/bin/deploy-impl.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Production deploy implementation for Hetzner. Invoked by the wrapper at
+# /home/deploy/openmv/bin/deploy.sh after that wrapper has fast-forwarded the
+# repo to origin/master. Living here keeps the actual deploy steps under
+# version control and reviewable in PRs.
+#
+# Run via the wrapper, not directly. The wrapper is the entry point baked
+# into the SSH deploy key's authorized_keys forced command.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "[deploy-impl] $(date -u +%FT%TZ) starting; HEAD=$(git rev-parse --short HEAD)"
+
+docker compose -f docker-compose.prod.yml up -d --build
+docker compose -f docker-compose.prod.yml ps
+
+# Give the web container a few seconds to run migrate + collectstatic and
+# bind to 8000 inside the container, then sanity-check it's responding.
+for i in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -sSf -o /dev/null --max-time 5 http://127.0.0.1:8001/; then
+        echo "[deploy-impl] web responding on 127.0.0.1:8001"
+        echo "[deploy-impl] $(date -u +%FT%TZ) done"
+        exit 0
+    fi
+    sleep 2
+done
+
+echo "[deploy-impl] web did not respond on 127.0.0.1:8001 within 20s"
+docker compose -f docker-compose.prod.yml logs --tail=40 web
+exit 1


### PR DESCRIPTION
## Summary

Adds a workflow that auto-deploys to the Hetzner production host on every push to `master`.

The deploy splits into three pieces, by design:

1. **Workflow** (`.github/workflows/deploy.yml`) — opens an SSH session to the `deploy` user on Hetzner using a key stored in the `HETZNER_SSH_KEY` secret. That's its entire job.
2. **Host wrapper** (`~/openmv/bin/deploy.sh` on Hetzner — **not in this PR**) — its path is baked into the deploy key's `authorized_keys` forced-command entry, so it has to live outside the repo. It's a 7-line script that does `git pull --ff-only && exec ./bin/deploy-impl.sh`. Set-and-forget.
3. **Deploy logic** (`bin/deploy-impl.sh` — in this PR) — runs `docker compose -f docker-compose.prod.yml up -d --build`, then sanity-curls `127.0.0.1:8001` with retries to confirm the web container survived `migrate` + `collectstatic` and booted gunicorn. Logs the last 40 lines of the web container if curl fails.

## Security model

The deploy key's `authorized_keys` entry uses a forced command:

```
command="/home/deploy/openmv/bin/deploy.sh",no-pty,no-port-forwarding,... ssh-ed25519 ...
```

The SSH server ignores anything the client wants to run and executes the forced command instead. Net effect: a leaked `HETZNER_SSH_KEY` can **only** trigger the deploy script. It cannot:
- open an interactive shell
- run docker commands directly
- read `.env` or other secrets on the host
- touch other apps on the same VPS (Factori.al, Caddy origin certs, root, etc.)

This matters because `deploy` is in the `docker` group, which is effectively root-equivalent. Without the forced command, a leaked key would give an attacker the entire VPS.

## Why split the wrapper out of the repo

The `authorized_keys` forced command needs a stable path. If `bin/deploy.sh` were in the repo, every PR that moved or renamed it could break deploy. The wrapper at `~/openmv/bin/deploy.sh` is the SSH entry point; `bin/deploy-impl.sh` (this file) is what you edit when you want to change deploy behaviour.

## Required GitHub secrets (set manually before merging)

| Name | Value |
|---|---|
| `HETZNER_SSH_KEY` | the private key (incl. `BEGIN`/`END` lines) of the deploy keypair |
| `HETZNER_HOST` | `178.104.167.195` |
| `HETZNER_USER` | `deploy` |

## Required Hetzner-side setup (also done manually)

```bash
# Generate the deploy keypair
ssh-keygen -t ed25519 -N "" -C "github-actions-deploy@openmv" -f ~/.ssh/github-deploy

# Create the stable wrapper (path is referenced from authorized_keys)
mkdir -p ~/openmv/bin
cat > ~/openmv/bin/deploy.sh <<'EOF'
#!/bin/bash
set -euo pipefail
cd /home/deploy/openmv/repo
git fetch origin master
git checkout master
git pull --ff-only origin master
exec ./bin/deploy-impl.sh
EOF
chmod +x ~/openmv/bin/deploy.sh

# Authorize the key with a forced command — locks it to deploy.sh only
PUBKEY=$(cat ~/.ssh/github-deploy.pub)
echo "command=\"/home/deploy/openmv/bin/deploy.sh\",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty $PUBKEY" >> ~/.ssh/authorized_keys

# Print the private key for the GitHub secret
cat ~/.ssh/github-deploy
```

## Test plan

- [ ] Hetzner-side setup done (wrapper + authorized_keys entry).
- [ ] All three GitHub secrets set.
- [ ] Merge this PR. The workflow should fire on the push-to-master event from the merge commit.
- [ ] In the workflow run, the SSH step should connect, the forced command should run the wrapper, the wrapper should exec `bin/deploy-impl.sh`, and the impl should report `web responding on 127.0.0.1:8001`. Total runtime ~30-60 seconds.
- [ ] After the run, refresh https://openmv.net/ to confirm the site is healthy.
- [ ] Rollback if something breaks: `cd /home/deploy/openmv/repo && git checkout <previous-sha> && docker compose -f docker-compose.prod.yml up -d --build` on Hetzner.

## Brief downtime expectation

`docker compose up -d --build` rebuilds the image (cached layers usually fast) and recreates the `web` container. The `db` container is unaffected (image unchanged). `web` recreation takes ~5 seconds, during which Caddy returns 502 to visitors. Acceptable for openmv's traffic.

https://claude.ai/code/session_0156oMTHWthdDv7cFxcHBaeV

---
_Generated by [Claude Code](https://claude.ai/code/session_0156oMTHWthdDv7cFxcHBaeV)_