### PR TITLE
Make dataset detail page render natively on mobile and desktop

### DIFF
--- a/datasetapp/templates/datasetapp/all_datasets.html
+++ b/datasetapp/templates/datasetapp/all_datasets.html
@@ -8,41 +8,41 @@ Datasets{% endif %}{% endblock %}
 <div id="special_message">{{ special_message|safe|escape }}</div>
 
 {% if show_home_page %}
+<p class="detail-topbar"><a href="{% url 'datasetapp:dataset-home-page' %}">&larr; Back to all datasets</a></p>
 <h3>Showing data sets with "{{current_tag}}" tag</h3>
-<span class="dataset-tag-right"><a href="{% url 'datasetapp:dataset-home-page' %}">Back to all datasets</a></span>
-<br>
-<span class="dataset-tag-left">{{current_tag_description}}</span>
+<p>{{current_tag_description}}</p>
 {% endif %}
 
-<br>
 <div class="dataset-results">
-
-    <table class="wikitable sortable">
-        <thead class="dataset-header">
-            <td style="padding-right: 10px;">Name</td>
-            <td>Description</td>
-            <td style="padding-left: 10px; padding-right: 10px;" id="rows">Rows</td>
-            <td style="padding-left: 10px; padding-right: 10px;" id="cols">Columns</td>
-            <!-- <td>Download</td> -->
-            <td style="text-align:left">Tags</td>
-        </thead>
-        {% for dataset in dataset_list %}
-        {% spaceless %}
-        <tr class="{% cycle 'row-odd' 'row-even' %} dataset-row">
-            <td style="padding-right: 10px;" width="20%"><a href="{% url 'datasetapp:dataset-about-a-dataset' dataset.slug %}">{{ dataset.name }}</a>
-            <td width="80%">{{dataset.description|striptags}}</td>
-            <td class="dataset-rows" width="8%">{{dataset.rows}}</td>
-            <td class="dataset-cols" width="10%">{{dataset.cols}}</td>
-            <td>
-                {% for tag in dataset.tags.all %}
-                <span><a href="{% url 'datasetapp:dataset-by-tag' tag %}" class="dataset-tag" title="{{tag.description}}">{{tag}}</a></span>
-                {% endfor %}
-            </td>
-        </tr>
-        {% endspaceless %}
-        {% endfor %}
-    </table>
-
-
+    <div class="table-responsive">
+        <table class="wikitable sortable table">
+            <thead class="dataset-header">
+                <tr>
+                    <td style="padding-right: 10px;">Name</td>
+                    <td>Description</td>
+                    <td style="padding-left: 10px; padding-right: 10px;" id="rows">Rows</td>
+                    <td style="padding-left: 10px; padding-right: 10px;" id="cols">Columns</td>
+                    <td style="text-align:left">Tags</td>
+                </tr>
+            </thead>
+            <tbody>
+            {% for dataset in dataset_list %}
+            {% spaceless %}
+            <tr class="{% cycle 'row-odd' 'row-even' %} dataset-row">
+                <td style="padding-right: 10px;"><a href="{% url 'datasetapp:dataset-about-a-dataset' dataset.slug %}">{{ dataset.name }}</a></td>
+                <td>{{dataset.description|striptags}}</td>
+                <td class="dataset-rows">{{dataset.rows}}</td>
+                <td class="dataset-cols">{{dataset.cols}}</td>
+                <td>
+                    {% for tag in dataset.tags.all %}
+                    <span><a href="{% url 'datasetapp:dataset-by-tag' tag %}" class="dataset-tag" title="{{tag.description}}">{{tag}}</a></span>
+                    {% endfor %}
+                </td>
+            </tr>
+            {% endspaceless %}
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
 </div>
 {% endblock %}

--- a/datasetapp/templates/datasetapp/base.html
+++ b/datasetapp/templates/datasetapp/base.html
@@ -1,24 +1,22 @@
 <head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css">
 <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
 <style>
-body {
-    padding: 4px;
+body { margin: 0; padding: 0; }
+.page-container {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 12px 16px;
+    box-sizing: border-box;
 }
-.calculated-width {
-    width: -moz-calc(100% - 100px);
-    width: -webkit-calc(100% - 100px);
-    width: calc(100% - 100px);
-    display: inline-block;
-}
-A{
-	font-size:20px;
+@media (min-width: 768px) {
+    .page-container { padding: 20px 28px; }
 }
 .row {
-	vertical-align: top;
-	padding-top: 4px;
-}
-.td{
+    vertical-align: top;
+    padding-top: 4px;
 }
 .row-odd{
     background: #DDDDDD;
@@ -55,35 +53,67 @@ A{
     text-align: center;
     vertical-align: top;
 }
-.dataset-tag-left{
-    float: left;
-}
-.dataset-tag-right{
-    float: right;
-}
+.dataset-tag-left, .dataset-tag-right { float: none; }
 .dataset-results{
     display: block;
 }
 
-#dataset-content{
-    float: left;
-    width: 65%;
+/* Detail-page layout: stacked on mobile, side-by-side >=768px */
+.detail-grid { display: block; }
+@media (min-width: 768px) {
+    .detail-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
+        gap: 32px;
+        align-items: start;
+    }
 }
-#dataset-download{
-    width: 25%;
-    float: right;
+#dataset-content { min-width: 0; }
+#dataset-download { min-width: 0; }
+
+/* Metadata definition list — replaces the 25%/75% <table> */
+.dataset-meta { margin: 0 0 16px 0; }
+.dataset-meta dt { font-weight: 600; color: #555; margin-top: 8px; }
+.dataset-meta dd { margin: 2px 0 0 0; }
+@media (min-width: 600px) {
+    .dataset-meta {
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        column-gap: 16px;
+        row-gap: 6px;
+    }
+    .dataset-meta dt { margin-top: 0; }
+    .dataset-meta dd { margin: 0; }
 }
-.dataset-title{
-    width: 30%;
-    vertical-align: top;
+
+.detail-topbar { margin: 0 0 8px 0; font-size: 14px; }
+.detail-topbar a { font-size: 14px; }
+
+#downloads-sparkline {
+    width: 100%;
+    max-width: 280px;
+    height: 50px;
+    margin-top: 6px;
 }
+
+.detail-nav {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 24px;
+    padding-top: 12px;
+    border-top: 1px solid #DDD;
+}
+.detail-nav .nav-prev { margin-right: auto; }
+.detail-nav .nav-next { margin-left: auto; }
 </style>
 <title>{% block title%}{% endblock %}</title>
 </head>
 <body>
-<div class="well calculated-width">
+<div class="well page-container">
 <h1>OpenMV.net Datasets</h1>
 {% block body %}{% endblock %}
 </div>
-<div>(c) Kevin Dunn, <a style="font-size: 14px;"href="https://learnche.org">learnche.org</a></div>
+<div class="page-container">(c) Kevin Dunn, <a href="https://learnche.org">learnche.org</a></div>
 </body>

--- a/datasetapp/templates/datasetapp/dataset_info.html
+++ b/datasetapp/templates/datasetapp/dataset_info.html
@@ -3,113 +3,95 @@
 
 {% block title %}{{ds.name|safe}}-OpenMV.net Datasets{% endblock %}
 {% block body %}
-<span class="dataset-tag-right"><a href="{% url 'datasetapp:dataset-home-page' %}">Back to all datasets</a></span>
+<p class="detail-topbar"><a href="{% url 'datasetapp:dataset-home-page' %}">&larr; Back to all datasets</a></p>
 
-<h3>{{ds.name}}</h3>
-<div id="dataset-content">
-    <table>
-        <tr>
-            <td class="dataset row" width="25%">Description:</td>
-            <td>{{ds.description|safe}}</td>
-        </tr>
-        <tr>
-            <td class="dataset row">Data source:</td>
-            <td>{{ds.data_source|safe}}</td>
-        </tr>
-        <tr>
-            <td class="dataset row">Data shape:</td>
-            <td>{{ds.rows}} rows and {{ds.cols}} columns</td>
-        </tr>
-        <tr>
-            <td class="dataset row">Usage restrictions:</td>
-            <td>{{ds.usage_restrictions}}</td>
-        </tr>
-        <tr>
-            <td class="dataset row">Contact person:</td>
-            <td>{{ds.author_name}}</td>
-        </tr>
-        <tr>
-            <td class="dataset row">Contact details:</td>
-            <td>{{ds.author_email}}</td>
-        </tr>
-        <tr>
-            <td class="dataset row">Added here on:</td>
-            <td>{{ds.created_on|date:"d F Y G:i"}}</td>
-        </tr>
-        <tr>
-            <td class="dataset row">Last updated:</td>
-            <td>{{ds.updated_on|date:"d F Y G:i"}}</td>
-        </tr>
-    </table>
+<h3>{{ ds.name }}</h3>
+
+<div class="detail-grid">
+    <div id="dataset-content">
+        <dl class="dataset-meta">
+            <dt>Description:</dt>        <dd>{{ ds.description|safe }}</dd>
+            <dt>Data source:</dt>        <dd>{{ ds.data_source|safe }}</dd>
+            <dt>Data shape:</dt>         <dd>{{ ds.rows }} rows and {{ ds.cols }} columns</dd>
+            <dt>Usage restrictions:</dt> <dd>{{ ds.usage_restrictions }}</dd>
+            <dt>Contact person:</dt>     <dd>{{ ds.author_name }}</dd>
+            <dt>Contact details:</dt>    <dd>{{ ds.author_email }}</dd>
+            <dt>Added here on:</dt>      <dd>{{ ds.created_on|date:"d F Y G:i" }}</dd>
+            <dt>Last updated:</dt>       <dd>{{ ds.updated_on|date:"d F Y G:i" }}</dd>
+        </dl>
+    </div>
+
+    <aside id="dataset-download">
+        <h4>Download</h4>
+        <a href="{% url 'datasetapp:dataset-download' file_name=download_file_name %}">{{ dfile.file_type }}</a>
+        &nbsp;[{{ num_hits }} download{{ num_hits|pluralize }}]
+
+        {% if num_hits %}
+        <div id="downloads-sparkline"></div>
+        <script>
+        (function() {
+            var data = {{ download_series_json|safe }};
+            var el = document.getElementById('downloads-sparkline');
+            var chart = echarts.init(el);
+            chart.setOption({
+                grid: {left: 0, right: 0, top: 4, bottom: 4},
+                xAxis: {type: 'category', show: false, data: data.map(function(d){return d[0];})},
+                yAxis: {type: 'value', show: false, min: 0},
+                tooltip: {
+                    trigger: 'axis',
+                    formatter: function(params) {
+                        var p = params[0];
+                        return p.name + '<br/>' + p.value + ' download' + (p.value === 1 ? '' : 's');
+                    }
+                },
+                series: [{
+                    type: 'line', data: data.map(function(d){return d[1];}),
+                    showSymbol: false, smooth: false,
+                    lineStyle: {width: 1.5, color: '#3E6D8E'},
+                    areaStyle: {color: 'rgba(62,109,142,0.15)'}
+                }]
+            });
+            window.addEventListener('resize', function(){ chart.resize(); });
+        })();
+        </script>
+        {% endif %}
+
+        <p>(Right-click link; choose "<i>Save Link As</i>")</p>
+
+        <h4>Tags for this dataset</h4>
+        {% for tag in ds.tags.all %}
+        <span><a href="{% url 'datasetapp:dataset-by-tag' tag %}" class="dataset-tag" title="{{ tag.description }}">{{ tag }}</a></span>
+        {% endfor %}
+    </aside>
 </div>
+
 {% if preview_rows %}
-<div id="dataset-preview" style="clear: both; margin-top: 16px;">
+<div id="dataset-preview" style="margin-top: 24px;">
     <h4>Preview (first {{ preview_rows|length|add:"-1" }} rows)</h4>
-    <table class="table table-striped table-condensed">
-        <thead>
-            <tr>{% for cell in preview_rows.0 %}<th>{{ cell }}</th>{% endfor %}</tr>
-        </thead>
-        <tbody>
-            {% for row in preview_rows|slice:"1:" %}
-            <tr>{% for cell in row %}<td>{{ cell }}</td>{% endfor %}</tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    <div class="table-responsive">
+        <table class="table table-striped table-condensed">
+            <thead>
+                <tr>{% for cell in preview_rows.0 %}<th>{{ cell }}</th>{% endfor %}</tr>
+            </thead>
+            <tbody>
+                {% for row in preview_rows|slice:"1:" %}
+                <tr>{% for cell in row %}<td>{{ cell }}</td>{% endfor %}</tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
 </div>
 {% endif %}
-<div id="dataset-download">
-
-    <h4>Download</h4>
-
-    <a href="{% url 'datasetapp:dataset-download' file_name=download_file_name %}">{{ dfile.file_type }}</a>
-    &nbsp;&nbsp;&nbsp;&nbsp; [{{num_hits}} download{{num_hits|pluralize}}]
-
-    {% if num_hits %}
-    <div id="downloads-sparkline" style="width: 220px; height: 50px; margin-top: 6px;"></div>
-    <script>
-    (function() {
-        var data = {{ download_series_json|safe }};
-        var chart = echarts.init(document.getElementById('downloads-sparkline'));
-        chart.setOption({
-            grid: {left: 0, right: 0, top: 4, bottom: 4},
-            xAxis: {type: 'category', show: false, data: data.map(function(d){return d[0];})},
-            yAxis: {type: 'value', show: false, min: 0},
-            tooltip: {
-                trigger: 'axis',
-                formatter: function(params) {
-                    var p = params[0];
-                    return p.name + '<br/>' + p.value + ' download' + (p.value === 1 ? '' : 's');
-                }
-            },
-            series: [{
-                type: 'line', data: data.map(function(d){return d[1];}),
-                showSymbol: false, smooth: false,
-                lineStyle: {width: 1.5, color: '#3E6D8E'},
-                areaStyle: {color: 'rgba(62,109,142,0.15)'}
-            }]
-        });
-    })();
-    </script>
-    {% endif %}
-
-    <p>(Right-click link; choose "<i>Save Link As</i>")
-
-    <h4>Tags for this dataset</h4>
-    {% for tag in ds.tags.all %}
-    <span><a href="{% url 'datasetapp:dataset-by-tag' tag %}" class="dataset-tag" title="{{tag.description}}">{{tag}}</a></span>
-    {% endfor %}
-
-</div>
 
 <script type="text/javascript"
     src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
-<nav style="clear: both; margin-top: 24px; padding-top: 12px; border-top: 1px solid #DDDDDD;">
+<nav class="detail-nav">
     {% if prev_dataset %}
-        <span style="float: left;">&larr; <a href="{% url 'datasetapp:dataset-about-a-dataset' prev_dataset.slug %}">{{ prev_dataset.name }}</a></span>
+        <span class="nav-prev">&larr; <a href="{% url 'datasetapp:dataset-about-a-dataset' prev_dataset.slug %}">{{ prev_dataset.name }}</a></span>
     {% endif %}
     {% if next_dataset %}
-        <span style="float: right;"><a href="{% url 'datasetapp:dataset-about-a-dataset' next_dataset.slug %}">{{ next_dataset.name }}</a> &rarr;</span>
+        <span class="nav-next"><a href="{% url 'datasetapp:dataset-about-a-dataset' next_dataset.slug %}">{{ next_dataset.name }}</a> &rarr;</span>
     {% endif %}
 </nav>
 {% endblock %}


### PR DESCRIPTION
## Summary

The recently-added CSV preview and ECharts sparkline broke the dataset detail page layout on iPad/phone (see issue screenshot): the title overlapped a floated "Back to all datasets" link, the 25%/75% metadata table wrapped awkwardly, and the download/sparkline block sat orphaned in the bottom-right with no visual relationship to the description above it.

Three causes drove most of it:

1. `base.html` had **no `<meta name="viewport">`**, so Bootstrap 3's responsive grid never engaged on mobile — the page rendered at a zoomed-out desktop viewport.
2. A global `A { font-size: 20px; }` rule made every anchor huge, including the floated "Back" link that overlapped the H1.
3. **Float-based two-column layout** (`#dataset-content { float: left; width: 65% }` + `#dataset-download { width: 25%; float: right }`) never reflowed on narrow viewports.

## Changes

- **`base.html`**: add viewport + UTF-8 meta; drop the global 20px anchor rule, `.calculated-width`, and the float-based `#dataset-content`/`#dataset-download` rules; add a mobile-first `.page-container` (`max-width: 1180px; margin: 0 auto`), a CSS-Grid `.detail-grid` (stacked on mobile, two-track from `768px`), a `.dataset-meta` definition-list grid (stacked on mobile, two-column from `600px`), `.detail-topbar`, `.detail-nav` (flex), and a fluid `#downloads-sparkline` (`width: 100%; max-width: 280px`).
- **`dataset_info.html`**: promote "Back to all datasets" to a small breadcrumb-style link above the H3; replace the metadata `<table>` with a semantic `<dl>`; put `#dataset-content` and `#dataset-download` inside `.detail-grid`; wrap the CSV preview in Bootstrap's `.table-responsive`; add a `window.resize` → `chart.resize()` listener so the sparkline reflows on rotation; replace the prev/next nav floats with flexbox.
- **`all_datasets.html`**: use the same `.detail-topbar` pattern for the "Back" link; wrap the listing in `.table-responsive`; add the missing `<thead>`/`<tbody>`/`<tr>` structure.

No view, URL, model, or dependency changes. Bootstrap 3.3.7, ECharts 5, and MathJax are unchanged. The IDs the smoke tests assert on (`#dataset-preview`, `#downloads-sparkline`, the `var data = …;` sparkline marker, and `/info/<slug>` prev/next links) are all preserved.

## Test plan

- [x] All nine pytest smoke tests in `datasetapp/tests/test_views.py` pass locally
- [x] `pre-commit run` clean on the three modified templates
- [x] All three templates compile via Django's template loader
- [ ] `make debug` and verify `/info/ammonia-concentration` in browser devtools at 375px / 768px / 1024px / 1440px viewports
- [ ] Spot-check a dataset where `preview_rows` is empty (preview block omitted) and one where `num_hits == 0` (sparkline `<script>` skipped)
- [ ] Deploy to `test.openmv.net` and re-check on the actual iPad that produced the original screenshot before merging to `master`

https://claude.ai/code/session_01FZw4dVRqHHuAz8PuhuMwox

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZw4dVRqHHuAz8PuhuMwox)_