### PR TITLE
Constrain homepage list table to viewport width

### DIFF
--- a/datasetapp/templates/datasetapp/all_datasets.html
+++ b/datasetapp/templates/datasetapp/all_datasets.html
@@ -14,35 +14,42 @@ Datasets{% endif %}{% endblock %}
 {% endif %}
 
 <div class="dataset-results">
-    <div class="table-responsive">
-        <table class="wikitable sortable table">
-            <thead class="dataset-header">
-                <tr>
-                    <td style="padding-right: 10px;">Name</td>
-                    <td>Description</td>
-                    <td style="padding-left: 10px; padding-right: 10px;" id="rows">Rows</td>
-                    <td style="padding-left: 10px; padding-right: 10px;" id="cols">Columns</td>
-                    <td style="text-align:left">Tags</td>
-                </tr>
-            </thead>
-            <tbody>
-            {% for dataset in dataset_list %}
-            {% spaceless %}
-            <tr class="{% cycle 'row-odd' 'row-even' %} dataset-row">
-                <td style="padding-right: 10px;"><a href="{% url 'datasetapp:dataset-about-a-dataset' dataset.slug %}">{{ dataset.name }}</a></td>
-                <td>{{dataset.description|striptags}}</td>
-                <td class="dataset-rows">{{dataset.rows}}</td>
-                <td class="dataset-cols">{{dataset.cols}}</td>
-                <td>
-                    {% for tag in dataset.tags.all %}
-                    <span><a href="{% url 'datasetapp:dataset-by-tag' tag %}" class="dataset-tag" title="{{tag.description}}">{{tag}}</a></span>
-                    {% endfor %}
-                </td>
+    <table class="wikitable sortable dataset-table">
+        <colgroup>
+            <col class="col-name">
+            <col class="col-desc">
+            <col class="col-rows">
+            <col class="col-cols">
+            <col class="col-tags">
+        </colgroup>
+        <thead class="dataset-header">
+            <tr>
+                <td>Name</td>
+                <td>Description</td>
+                <td id="rows">Rows</td>
+                <td id="cols">Columns</td>
+                <td>Tags</td>
             </tr>
-            {% endspaceless %}
-            {% endfor %}
-            </tbody>
-        </table>
-    </div>
+        </thead>
+        <tbody>
+        {% for dataset in dataset_list %}
+        {% spaceless %}
+        <tr class="{% cycle 'row-odd' 'row-even' %} dataset-row">
+            <td><a href="{% url 'datasetapp:dataset-about-a-dataset' dataset.slug %}">{{ dataset.name }}</a></td>
+            <td>{{dataset.description|striptags}}</td>
+            <td class="dataset-rows">{{dataset.rows}}</td>
+            <td class="dataset-cols">{{dataset.cols}}</td>
+            <td>
+                <div class="tag-list">
+                {% for tag in dataset.tags.all %}
+                <a href="{% url 'datasetapp:dataset-by-tag' tag %}" class="dataset-tag" title="{{tag.description}}">{{tag}}</a>
+                {% endfor %}
+                </div>
+            </td>
+        </tr>
+        {% endspaceless %}
+        {% endfor %}
+        </tbody>
+    </table>
 </div>
 {% endblock %}

--- a/datasetapp/templates/datasetapp/base.html
+++ b/datasetapp/templates/datasetapp/base.html
@@ -58,6 +58,40 @@ body { margin: 0; padding: 0; }
     display: block;
 }
 
+/* Homepage list table — predictable column widths so wide content wraps
+   instead of pushing the layout past the viewport. */
+.dataset-table {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+}
+.dataset-table td {
+    padding: 6px 8px;
+    vertical-align: top;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+.dataset-table .col-name { width: 18%; }
+.dataset-table .col-desc { width: auto; }
+.dataset-table .col-rows { width: 8%; }
+.dataset-table .col-cols { width: 10%; }
+.dataset-table .col-tags { width: 22%; }
+.tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+@media (max-width: 600px) {
+    .dataset-table .col-rows,
+    .dataset-table .col-cols { width: 0; }
+    .dataset-table thead td:nth-child(3),
+    .dataset-table thead td:nth-child(4),
+    .dataset-table tbody td:nth-child(3),
+    .dataset-table tbody td:nth-child(4) { display: none; }
+    .dataset-table .col-name { width: 30%; }
+    .dataset-table .col-tags { width: 26%; }
+}
+
 /* Detail-page layout: stacked on mobile, side-by-side >=768px */
 .detail-grid { display: block; }
 @media (min-width: 768px) {


### PR DESCRIPTION
## Summary

Follow-up to #53. After that PR, the homepage list table on iPad was rendering wider than the viewport — the Description, Rows, Columns, and Tags columns were pushed off the right edge and only the Name column plus a truncated Description fragment were visible.

Two causes:

1. The `<div class="table-responsive">` wrapper I added in #53 enabled `overflow-x: auto`, so the table was free to grow past the viewport instead of being constrained to it.
2. `.dataset-tag { white-space: nowrap }` plus `{% spaceless %}` stripping the whitespace between adjacent tag chips meant a row with several tags forced its cell wide enough to push the table past the viewport edge.

## Fix

- Drop the `.table-responsive` wrapper from the listing.
- Switch the listing to `table-layout: fixed` with explicit column proportions via `<colgroup>` (`18% / auto / 8% / 10% / 22%`), and `overflow-wrap: break-word` on cells so long descriptions wrap within their column.
- Wrap tag chips in a flex `.tag-list` div so they flow onto multiple lines cleanly. Individual chips keep `white-space: nowrap` so tag names don't break mid-word.
- Below 600px the Rows and Columns numeric columns collapse so Name / Description / Tags get room on phones.

The CSV preview in `dataset_info.html` still uses `.table-responsive` — that's correct, since CSVs have unknown column widths and may genuinely benefit from horizontal scroll.

## Test plan

- [x] All nine pytest smoke tests in `datasetapp/tests/test_views.py` pass locally
- [x] `pre-commit run` clean on the two modified templates
- [ ] `make debug` and verify `/` (the homepage) at 375px / 768px / 1024px / 1440px viewports — table fits viewport, all five columns visible at >=600px, Rows/Columns hidden at <600px
- [ ] Verify a row with many tags wraps the chips onto multiple lines instead of overflowing the column
- [ ] Spot-check `/tag/<some-tag>` (`display_by_tag` view uses the same template)
- [ ] Deploy to `test.openmv.net` and re-check on the actual iPad that produced the overflow screenshot

https://claude.ai/code/session_01FZw4dVRqHHuAz8PuhuMwox

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZw4dVRqHHuAz8PuhuMwox)_