### PR TITLE
Show current year in footer automatically

### DIFF
--- a/datasetapp/templates/datasetapp/base.html
+++ b/datasetapp/templates/datasetapp/base.html
@@ -479,7 +479,7 @@ p  { margin: 0 0 var(--sp-3) 0; }
 {% block body %}{% endblock %}
 </main>
 <footer class="site-footer">
-    <p>(c) Kevin Dunn, <a href="https://learnche.org">learnche.org</a></p>
+    <p>(c) 2010&ndash;{% now "Y" %} Kevin Dunn, <a href="https://learnche.org">learnche.org</a></p>
 </footer>
 
 <script>


### PR DESCRIPTION
## Summary

- Footer in `datasetapp/templates/datasetapp/base.html` now reads `(c) 2010–YYYY Kevin Dunn, learnche.org` using Django's built-in `{% now "Y" %}` template tag.
- The year auto-rolls on Jan 1 (Berlin midnight, per `TIME_ZONE` in `openmv/settings.py`) — no redeploy needed.
- Single-line edit; `base.html` is the only template with a footer block, so every page (homepage, tag list, detail page) inherits it.

## Audit of already-implemented issues

While in here, two open issues turn out to already be done in the codebase. They will be closed with a confirming comment after this PR lands:

- **#7** — `Dataset.objects.filter(...)[0]` → `.first()` + `None` check. Both call sites (`datasetapp/views.py:148`, `:204`) already use `.first()`. The remaining `DataFile.objects.filter(...)[0]` at `:212-214` is a separate concern flagged in CLAUDE.md gotcha #4 and out of scope of #7.
- **#8** — Hardcoded `/info/`, `/file/`, `/tag/` paths replaced with `{% url %}`. All template links already use `{% url %}` (`all_datasets.html:9, 40, 47`; `dataset_info.html:6, 26, 77, 107, 110`).

## Test plan

- [x] `uv run pytest` — 9/9 smoke tests pass.
- [ ] After merge: visit https://test.openmv.net/ and confirm footer renders `(c) 2010–2026 Kevin Dunn, learnche.org` on the homepage, a tag page, and a detail page.

https://claude.ai/code/session_017YNCXdudnHhaE3NWfumBHw

---
_Generated by [Claude Code](https://claude.ai/code/session_017YNCXdudnHhaE3NWfumBHw)_