### PR TITLE
Add Python quickstart code block to dataset detail page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ The Django site behind <https://openmv.net> — a dataset catalogue that lists, 
 - **Templates** (`datasetapp/templates/datasetapp/`):
   - `base.html` — Bootstrap 3 layout, inline `<style>`, no static-file dependency. Loads ECharts (CDN) for the detail-page sparkline.
   - `all_datasets.html` — the list page.
-  - `dataset_info.html` — the detail page. Pulls in MathJax for any LaTeX in descriptions, renders a 365-day downloads sparkline (ECharts) below the download counter, an inline CSV preview table (first 10 rows) above the download block, and prev/next dataset links at the bottom.
+  - `dataset_info.html` — the detail page. Pulls in MathJax for any LaTeX in descriptions, renders a 365-day downloads sparkline (ECharts) below the download counter, a Python quickstart code block with a copy-to-clipboard button (rendered when a CSV file exists), an inline CSV preview table (first 10 rows) above the download block, and prev/next dataset links at the bottom.
 - **Custom template tag**: `datasetapp/templatetags/extra_tags.py` defines a `slice_string` filter used in templates to trim filenames.
 - **Admin**: registered in `datasetapp/admin.py` with `list_per_page = 2000` (deliberate — small dataset count).
 

--- a/datasetapp/templates/datasetapp/base.html
+++ b/datasetapp/templates/datasetapp/base.html
@@ -421,6 +421,64 @@ p  { margin: 0 0 var(--sp-3) 0; }
 
 #downloads-sparkline { width: 100%; max-width: 280px; height: 50px; margin-top: var(--sp-3); }
 
+/* Quickstart code block */
+.quickstart { margin-top: var(--sp-6); }
+.quickstart__head {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: var(--sp-3);
+    margin: 0 0 var(--sp-2) 0;
+}
+.quickstart__head h4 {
+    margin: 0;
+    font-family: var(--font-sans); font-weight: 600; color: var(--color-text);
+}
+.code-block {
+    margin: 0;
+    padding: var(--sp-4);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    overflow-x: auto;
+    font-family: var(--font-mono);
+    font-size: var(--fs-sm);
+    line-height: 1.55;
+    color: var(--color-text);
+    box-shadow: var(--shadow-sm);
+}
+.code-block code { font-family: inherit; white-space: pre; }
+.code-copy-btn {
+    display: inline-flex; align-items: center; gap: var(--sp-2);
+    padding: 4px var(--sp-3);
+    border: 1px solid var(--color-border-strong);
+    border-radius: 999px;
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    font-family: var(--font-mono);
+    font-size: var(--fs-xs);
+    text-transform: uppercase; letter-spacing: 0.08em;
+    transition: background var(--transition), color var(--transition), border-color var(--transition);
+}
+.code-copy-btn:hover {
+    background: var(--color-surface-2);
+    color: var(--color-text);
+    border-color: var(--color-accent);
+}
+.code-copy-btn.is-copied {
+    color: var(--color-accent-soft-fg);
+    background: var(--color-accent-soft);
+    border-color: var(--color-accent);
+}
+.code-copy-btn__icon {
+    width: 14px; height: 14px; display: inline-block;
+    background: currentColor;
+    -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><rect x='9' y='9' width='13' height='13' rx='2' ry='2'/><path d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'/></svg>") center/contain no-repeat;
+            mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><rect x='9' y='9' width='13' height='13' rx='2' ry='2'/><path d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'/></svg>") center/contain no-repeat;
+}
+.code-copy-btn.is-copied .code-copy-btn__icon {
+    -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='20 6 9 17 4 12'/></svg>") center/contain no-repeat;
+            mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='20 6 9 17 4 12'/></svg>") center/contain no-repeat;
+}
+
 .preview-wrapper { margin-top: var(--sp-6); }
 .preview-wrapper > h4 { font-family: var(--font-sans); font-weight: 600; color: var(--color-text); }
 .preview-scroll {

--- a/datasetapp/templates/datasetapp/dataset_info.html
+++ b/datasetapp/templates/datasetapp/dataset_info.html
@@ -81,6 +81,58 @@
     </aside>
 </div>
 
+{% if quickstart_url %}
+<section id="dataset-quickstart" class="quickstart">
+    <div class="quickstart__head">
+        <h4>Load this dataset in Python</h4>
+        <button type="button" class="code-copy-btn" data-copy-target="#quickstart-code"
+                aria-label="Copy code to clipboard">
+            <span class="code-copy-btn__icon" aria-hidden="true"></span>
+            <span class="code-copy-btn__label">Copy</span>
+        </button>
+    </div>
+    <pre class="code-block"><code id="quickstart-code" class="language-python">import pandas as pd
+
+df = pd.read_csv("{{ quickstart_url }}")
+df.describe()</code></pre>
+</section>
+<script>
+(function () {
+    document.querySelectorAll('.code-copy-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var sel = btn.getAttribute('data-copy-target');
+            var target = sel ? document.querySelector(sel) : null;
+            if (!target) return;
+            var text = target.textContent;
+            var done = function () {
+                var label = btn.querySelector('.code-copy-btn__label');
+                var original = label ? label.textContent : '';
+                btn.classList.add('is-copied');
+                if (label) label.textContent = 'Copied';
+                setTimeout(function () {
+                    btn.classList.remove('is-copied');
+                    if (label) label.textContent = original;
+                }, 1500);
+            };
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(text).then(done, function () {});
+            } else {
+                var ta = document.createElement('textarea');
+                ta.value = text;
+                ta.setAttribute('readonly', '');
+                ta.style.position = 'absolute';
+                ta.style.left = '-9999px';
+                document.body.appendChild(ta);
+                ta.select();
+                try { document.execCommand('copy'); done(); } catch (e) {}
+                document.body.removeChild(ta);
+            }
+        });
+    });
+})();
+</script>
+{% endif %}
+
 {% if preview_rows %}
 <div id="dataset-preview" class="preview-wrapper">
     <h4>Preview (first {{ preview_rows|length|add:"-1" }} rows)</h4>

--- a/datasetapp/views.py
+++ b/datasetapp/views.py
@@ -170,6 +170,16 @@ def about_dataset(request, dataset_name=None):
     dfile = files[0]
     download_file_name = f"{ds.slug}.{dfile.file_type.lower()}"
 
+    # Python quickstart (only when a CSV is available).
+    quickstart_url = None
+    if csv_file is not None and not ds.is_hidden:
+        quickstart_url = request.build_absolute_uri(
+            django_reverse(
+                "datasetapp:dataset-download",
+                kwargs={"file_name": f"{ds.slug}.csv"},
+            )
+        )
+
     context = {
         "ds": ds,
         "dfile": dfile,
@@ -178,6 +188,7 @@ def about_dataset(request, dataset_name=None):
         "prev_dataset": prev_dataset,
         "next_dataset": next_dataset,
         "preview_rows": preview_rows,
+        "quickstart_url": quickstart_url,
         "download_series_json": json.dumps(_download_series(ds)),
     }
     return TemplateResponse(request, "datasetapp/dataset_info.html", context)


### PR DESCRIPTION
## Summary
- New "Load this dataset in Python" block on every dataset detail page (when a CSV file is attached and the dataset is not hidden) showing a pandas snippet that reads straight from the dataset's public HTTPS URL and calls `df.describe()`.
- One-click copy-to-clipboard button (clipboard icon → checkmark + "Copied" feedback) using the Clipboard API with a `document.execCommand('copy')` fallback.
- The URL is built with `request.build_absolute_uri()` against `dataset-download`, so it's the same `/file/<slug>.csv` route the download button uses — i.e. each `pd.read_csv` call is logged as a `Hit` (the redirect is followed transparently by pandas/`urllib`).

## Implementation
- `datasetapp/views.py`: compute `quickstart_url` in `about_dataset` and pass it through context. Gate on `csv_file is not None and not ds.is_hidden`, mirroring the CSV-preview path.
- `datasetapp/templates/datasetapp/dataset_info.html`: render a `<section id="dataset-quickstart">` with the code in a `<pre><code>` block and an inline `<script>` that wires every `.code-copy-btn` on the page.
- `datasetapp/templates/datasetapp/base.html`: styles for `.quickstart`, `.code-block`, and `.code-copy-btn` (light/dark themes via existing CSS variables; icon swaps to a checkmark on success).
- `CLAUDE.md`: detail-page description updated.

## Test plan
- [x] `uv run pytest -q` — all 9 tests pass
- [x] Local runserver: `/info/iris` renders the new section with the absolute URL, copy button, and code body
- [ ] Visual check on `test.openmv.net` after merge to staging (light + dark themes, mobile width)
- [ ] Verify the copy button works in Safari/Firefox/Chrome
- [ ] Confirm the rendered URL is `https://openmv.net/file/<slug>.csv` in production (via `SECURE_PROXY_SSL_HEADER`)

https://claude.ai/code/session_01HLD4UtBSYSSe7y5DAnQuNV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLD4UtBSYSSe7y5DAnQuNV)_