### PR TITLE
Fix issues #5 (manager rename) and #11 (settings split)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,8 @@
 #   python -c "import secrets; print(secrets.token_urlsafe(50))"
 SECRET_KEY=change-me
 
-# 1 = development (SQLite, debug toolbar, verbose errors).
-# 0 = production (PostgreSQL using the keys below).
-DJANGO_DEBUG=1
-
-# Postgres connection details. Only consulted when DJANGO_DEBUG=0.
+# Postgres connection details. Only consulted by `openmv.settings.prod`;
+# `openmv.settings.dev` uses SQLite.
 POSTGRES_DB=openmv
 POSTGRES_USER=openmv
 POSTGRES_PASSWORD=change-me

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,14 @@ jobs:
       - name: Install dependencies (locked)
         run: uv sync --frozen
 
-      # `openmv/settings.py` asserts that .env exists at import time, so the
-      # test runner blows up without one. Synthesize a minimal .env here.
+      # `openmv/settings/base.py` asserts that .env exists at import time, so
+      # the test runner blows up without one. Synthesize a minimal .env here.
       # TODO: drop this once settings reads from os.environ first.
       # Tracked in the "stop asserting .env exists" follow-up issue.
       - name: Create stub .env for tests
         run: |
           cat > .env <<'EOF'
           SECRET_KEY=ci-test-key
-          DJANGO_DEBUG=1
           EOF
 
       - name: Lint (pre-commit)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ The Django site behind <https://openmv.net> — a dataset catalogue that lists, 
 
 ## Project shape
 
-- **Project**: `openmv/` (settings, URL conf, WSGI/ASGI).
+- **Project**: `openmv/` (settings package, URL conf, WSGI/ASGI). Settings live under `openmv/settings/` — `base.py` (shared), `dev.py` (local SQLite + DEBUG=True), `prod.py` (Postgres + DEBUG=False + Caddy proxy headers).
 - **App**: `datasetapp/` (the only app).
 - **Models** (`datasetapp/models.py`): `Tag`, `Dataset`, `DataFile`, `Hit`.
   - `Dataset` ↔ `Tag` is many-to-many.
@@ -31,11 +31,10 @@ The Django site behind <https://openmv.net> — a dataset catalogue that lists, 
 ## How it runs
 
 - `make debug` runs `collectstatic --no-input`, `migrate`, `createcachetable`, then `runserver 8080 --nostatic`.
-- Settings load `.env` via `python-dotenv`'s `dotenv_values()`. The file is **required** — `openmv/settings.py` asserts it exists on import.
-- Database backend switches on `DJANGO_DEBUG`:
-  - `1` → SQLite (`db.sqlite3` next to `manage.py`).
-  - `0` → PostgreSQL using `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `SQL_HOST`, `SQL_PORT`.
-- `ALLOWED_HOSTS = [".openmv.net", "127.0.0.1"]` is hardcoded in settings.
+- Settings load `.env` via `python-dotenv`'s `dotenv_values()`. The file is **required** — `openmv/settings/base.py` asserts it exists on import (CI synthesises a stub).
+- Which DB / hosts / DEBUG flag you get depends on `DJANGO_SETTINGS_MODULE`:
+  - `openmv.settings.dev` (default in `manage.py`, `wsgi.py`, `asgi.py`, `pyproject.toml` pytest) → SQLite at `db.sqlite3`, `DEBUG=True`, `ALLOWED_HOSTS=['127.0.0.1', 'localhost']`.
+  - `openmv.settings.prod` (forced by `docker-compose.prod.yml`'s `web.environment` block) → Postgres via `POSTGRES_*` + `SQL_*` keys, `DEBUG=False`, `ALLOWED_HOSTS=['.openmv.net', '127.0.0.1']`, `SECURE_PROXY_SSL_HEADER` + `CSRF_TRUSTED_ORIGINS` for Caddy.
 
 ## Running locally
 
@@ -43,17 +42,17 @@ Two paths:
 
 **Native (uv):**
 ```bash
-cp .env.example .env   # edit SECRET_KEY; leave DJANGO_DEBUG=1 for SQLite
+cp .env.example .env   # edit SECRET_KEY
 uv sync --dev
 make debug             # collectstatic + migrate + createcachetable + runserver:8080
 ```
 
-**Docker compose (with Postgres for parity with prod):**
+**Docker compose (`make docker-up` → SQLite + runserver in a container):**
 ```bash
-cp .env.example .env   # set SECRET_KEY and the POSTGRES_* keys; set DJANGO_DEBUG=0
+cp .env.example .env   # set SECRET_KEY
 make docker-up         # docker compose up --build
 ```
-Both paths serve <http://127.0.0.1:8080/>.
+Both paths use `openmv.settings.dev` and serve <http://127.0.0.1:8080/>. To rehearse the production stack (Postgres + gunicorn + `openmv.settings.prod`), use `docker compose -f docker-compose.prod.yml up --build` instead.
 
 ## Production deployment (Hetzner)
 
@@ -75,7 +74,8 @@ Cloudflare (proxied, orange cloud) ──HTTPS──> Caddy on Hetzner host (TLS
   - `media/` — Django uploads served by Caddy and mounted into the container as `/app/media`.
   - `static/` — `collectstatic` output, mounted as `/app/static`. Re-populated by the `web` container's startup command.
   - `public/` — host the small files Apache used to alias (`robots.txt`, `favicon.ico`, `blender-efficiency.xlsx`).
-- **`.env`** is **bind-mounted** into the container (`./.env:/app/.env:ro`) because `settings.py` reads the file at import time and `.dockerignore` excludes it from the image. Never commit `.env`.
+- **`.env`** is **bind-mounted** into the container (`./.env:/app/.env:ro`) because `openmv/settings/base.py` reads the file at import time and `.dockerignore` excludes it from the image. Never commit `.env`.
+- **`DJANGO_SETTINGS_MODULE=openmv.settings.prod`** is set on the `web` service in `docker-compose.prod.yml`; this is what selects the prod-only DB / hosts / proxy headers. Don't rely on the `manage.py` default for production.
 - **Caddy config**: `/etc/caddy/Caddyfile` on the host. Reload with `sudo systemctl reload caddy` (validate first with `sudo caddy validate --config /etc/caddy/Caddyfile`).
 - **TLS**:
   - `openmv.net` and `www.openmv.net` use a **Cloudflare Origin Certificate** (15-year, signed by Cloudflare's internal CA) at `/etc/caddy/origin-certs/openmv.net/`. Cloudflare's edge serves a public-trusted cert to visitors and re-encrypts to origin in `Full (strict)` mode.
@@ -86,7 +86,7 @@ Cloudflare (proxied, orange cloud) ──HTTPS──> Caddy on Hetzner host (TLS
 
 ## Gotchas worth knowing before editing
 
-1. **`DatasetManager.get_query_set` is dead code.** It uses the pre-Django-1.6 method name; the modern name is `get_queryset`. Right now `is_hidden=True` datasets are still rendered on the homepage. Renaming the method will make those rows disappear — verify with the site owner before flipping the switch.
+1. **`DatasetManager.get_queryset` filters out `is_hidden=True` rows from the public site _and_ from the admin list.** `Dataset.objects` is the only manager, so the admin's `DatasetAdmin` queryset is filtered too. To re-edit a hidden dataset, flip `is_hidden` directly in the DB (`./manage.py shell` or a `psql` session) — there is no `all_objects` escape hatch.
 2. **`download_dataset` relies on the file URL being publicly reachable.** It returns `HttpResponseRedirect(file_obj.link_to_file.url)`. In production Caddy serves `/media/` directly from a bind-mounted host directory. Locally, `openmv/urls.py` wires `static(MEDIA_URL, document_root=MEDIA_ROOT)` under `DEBUG=True` so `runserver` serves uploads from `BASE_DIR/media/` (the `--nostatic` flag in `make debug` only suppresses the staticfiles app's auto-serving and does not affect those explicit URL patterns).
 3. **`DataFile.link_to_file` values stored in the DB are `datasets/<file>.<ext>`** (no leading `media/`). Linode's legacy data had a `media/` prefix that was stripped during the Hetzner cutover. If you ever re-restore from a stale Linode dump, re-run: `UPDATE datasetapp_datafile SET link_to_file = regexp_replace(link_to_file, '^media/', '') WHERE link_to_file LIKE 'media/%';`
 4. **`DataFile.objects.filter(...)[0]` in `download_dataset`** still uses `[0]` indexing inside a `try/except IndexError`. If you "tidy" it to `.first()`, preserve the same 404 path. (The two `Dataset.objects.filter(...)[0]` siblings have already been migrated to `.first()` + `None` check.)
@@ -101,8 +101,8 @@ Cloudflare (proxied, orange cloud) ──HTTPS──> Caddy on Hetzner host (TLS
   - Refresh the lockfile after manual edits: `uv lock`
   - Django is pinned `>=4.2,<5.0` until 5.x has been smoke-tested on staging.
 - **Tests** run with `uv run pytest` (or `make test`). `pytest-django` is wired through `[tool.pytest.ini_options]` in `pyproject.toml`. Smoke suite lives in `datasetapp/tests/test_views.py`.
-- **GitHub Actions** runs `pre-commit run --all-files` and `pytest` on every PR and on push to `master` (`.github/workflows/ci.yml`). The job synthesizes a stub `.env` because `openmv/settings.py` asserts one exists at import — see the "stop asserting `.env` exists" follow-up issue.
-- **Docker compose**: `docker-compose.yml` is for **local development** (volume-mounts the source for hot reload, runs `runserver`, exposes Postgres on `5432`). `docker-compose.prod.yml` is the **production** compose used on Hetzner (bind-mounts `.env` and `data/` dirs, runs `migrate` + `collectstatic` + `gunicorn`, binds to loopback on offset ports `8001`/`5434`). Both use the same `Dockerfile`.
+- **GitHub Actions** runs `pre-commit run --all-files` and `pytest` on every PR and on push to `master` (`.github/workflows/ci.yml`). The job synthesizes a stub `.env` because `openmv/settings/base.py` asserts one exists at import — see the "stop asserting `.env` exists" follow-up issue.
+- **Docker compose**: `docker-compose.yml` is for **local development** (volume-mounts the source for hot reload, runs `runserver` against SQLite via `openmv.settings.dev`). `docker-compose.prod.yml` is the **production** compose used on Hetzner (bind-mounts `.env` and `data/` dirs, sets `DJANGO_SETTINGS_MODULE=openmv.settings.prod`, runs `migrate` + `collectstatic` + `gunicorn`, binds to loopback on offset ports `8001`/`5434`). Both use the same `Dockerfile`.
 - **pre-commit** is configured (`.pre-commit-config.yaml`) — hooks are kept on current stable releases (`pre-commit-hooks` v5, `mypy` v1.13, `isort` 5.13, `black` 24.10, `blacken-docs` 1.19, `flake8` 7.1). Refresh with `pre-commit autoupdate` and re-run `pre-commit run --all-files` before merging.
 - **flake8** config: `.flake8`. Line length 100. Ignores E266/E203/E231/W503.
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ The site lets visitors:
 ├── pyproject.toml            # uv-managed dependencies + pytest config
 ├── uv.lock                   # committed lockfile
 ├── Dockerfile                # multi-stage image for local dev (and future prod)
-├── docker-compose.yml        # web + postgres for local dev parity
+├── docker-compose.yml        # local dev (SQLite, runserver)
+├── docker-compose.prod.yml   # production (Postgres, gunicorn)
 ├── .github/workflows/ci.yml  # pre-commit + pytest on push and PR
 ├── openmv/                   # Django project (settings, root URLs, WSGI/ASGI)
-│   ├── settings.py
+│   ├── settings/             # base.py + dev.py + prod.py
 │   ├── urls.py
 │   ├── wsgi.py
 │   └── asgi.py
@@ -47,7 +48,7 @@ The site lets visitors:
 
 - Python 3.11+
 - [uv](https://docs.astral.sh/uv/) for dependency management
-- PostgreSQL (production / docker compose) — SQLite is used automatically when `DJANGO_DEBUG=1`.
+- PostgreSQL (production only, via `openmv.settings.prod`). Local dev uses SQLite via `openmv.settings.dev`.
 
 Dependencies are declared in `pyproject.toml` and pinned in `uv.lock`.
 
@@ -64,8 +65,9 @@ uv sync --dev
 
 # 3. Configure environment
 cp .env.example .env
-# Edit .env: set SECRET_KEY to any random string, leave DJANGO_DEBUG=1.
-# The Postgres-related keys are only consulted when DJANGO_DEBUG=0.
+# Edit .env: set SECRET_KEY to any random string. The Postgres keys are
+# only consulted by openmv.settings.prod, so they can stay as the
+# placeholders for local dev.
 
 # 4. Run the dev server (collectstatic + migrate + createcachetable + runserver:8080)
 make debug
@@ -74,11 +76,13 @@ make debug
 ### Docker compose
 
 ```bash
-cp .env.example .env   # set SECRET_KEY and POSTGRES_*; set DJANGO_DEBUG=0
-make docker-up         # builds + starts web (Django) and db (Postgres)
+cp .env.example .env   # set SECRET_KEY
+make docker-up         # builds + runs runserver against SQLite
 ```
 
-Either path serves <http://127.0.0.1:8080/>. Create a superuser with `uv run python manage.py createsuperuser` (native) or `docker compose exec web python manage.py createsuperuser` (Docker) to log into `/admin/` and add Tags / Datasets / DataFiles.
+Both paths use `openmv.settings.dev` (SQLite) and serve <http://127.0.0.1:8080/>. To rehearse the production stack locally (Postgres + gunicorn + `openmv.settings.prod`), use `docker compose -f docker-compose.prod.yml up --build` instead.
+
+Create a superuser with `uv run python manage.py createsuperuser` (native) or `docker compose exec web python manage.py createsuperuser` (Docker) to log into `/admin/` and add Tags / Datasets / DataFiles.
 
 ## Testing & CI
 
@@ -88,8 +92,8 @@ Either path serves <http://127.0.0.1:8080/>. Create a superuser with `uv run pyt
 
 ## Production notes
 
-- `DJANGO_DEBUG=0` switches the database to PostgreSQL using `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `SQL_HOST`, `SQL_PORT` from `.env`.
-- `ALLOWED_HOSTS` is hardcoded to `.openmv.net` and `127.0.0.1` in `openmv/settings.py`. Change it there for other deployments.
+- Production sets `DJANGO_SETTINGS_MODULE=openmv.settings.prod` (wired in `docker-compose.prod.yml`), which selects PostgreSQL via `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `SQL_HOST`, `SQL_PORT` from `.env` and turns off `DEBUG`.
+- `ALLOWED_HOSTS` is hardcoded to `.openmv.net` and `127.0.0.1` in `openmv/settings/prod.py`. Change it there for other deployments.
 - Static files land in `BASE_DIR / 'static'` after `python manage.py collectstatic`. Admin-uploaded dataset files land in `BASE_DIR / 'media'` (`MEDIA_ROOT`), reachable at `/media/` (`MEDIA_URL`). The live site has Apache serving `/static/` and `/media/` directly; the `download_dataset` view returns a 302 to the `/media/...` URL rather than streaming the file through Django. Locally, `runserver` serves `/media/` only when `DJANGO_DEBUG=1` (see `openmv/urls.py`); in production Apache must be configured to intercept `/media/` before the request reaches Django.
 - The `Hit` table grows with every download. There is no automatic pruning.
 

--- a/datasetapp/models.py
+++ b/datasetapp/models.py
@@ -19,8 +19,8 @@ class Tag(models.Model):
 
 
 class DatasetManager(models.Manager):
-    def get_query_set(self):
-        return super(DatasetManager, self).get_query_set().filter(is_hidden=False)
+    def get_queryset(self):
+        return super().get_queryset().filter(is_hidden=False)
 
 
 class Dataset(models.Model):

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,12 +34,13 @@ services:
     container_name: openmv-app
     env_file: .env
     environment:
+      DJANGO_SETTINGS_MODULE: openmv.settings.prod
       SQL_HOST: db
       SQL_PORT: 5432
     volumes:
-      # openmv/settings.py reads the .env file at BASE_DIR / ".env" at import
-      # time (not just environment variables), so the file itself must be
-      # present in the container. .dockerignore excludes it from the image,
+      # openmv/settings/base.py reads the .env file at BASE_DIR / ".env" at
+      # import time (not just environment variables), so the file itself must
+      # be present in the container. .dockerignore excludes it from the image,
       # so we bind-mount the host copy read-only.
       - ./.env:/app/.env:ro
       - ./data/media:/app/media

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
-# Local development only. Production still ships from Apache; the
-# production-Docker rollout is tracked in a follow-up issue.
+# Local development only. Runs `runserver` against SQLite (matches
+# `openmv.settings.dev`). For prod-parity testing (Postgres + gunicorn),
+# use `docker-compose.prod.yml` instead.
 #
 # Usage:
 #   cp .env.example .env   # then edit SECRET_KEY etc.
@@ -7,37 +8,14 @@
 # Visit http://127.0.0.1:8080/
 
 services:
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
   web:
     build: .
     env_file: .env
     environment:
-      SQL_HOST: db
-      SQL_PORT: 5432
+      DJANGO_SETTINGS_MODULE: openmv.settings.dev
     volumes:
       - .:/app
     ports:
       - "8080:8000"
-    depends_on:
-      db:
-        condition: service_healthy
     # Override the image's gunicorn CMD with runserver for hot reload.
     command: python manage.py runserver 0.0.0.0:8000
-
-volumes:
-  postgres_data:

--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openmv.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openmv.settings.dev")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/openmv/asgi.py
+++ b/openmv/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openmv.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openmv.settings.dev")
 
 application = get_asgi_application()

--- a/openmv/settings/base.py
+++ b/openmv/settings/base.py
@@ -10,6 +10,7 @@ and https://docs.djangoproject.com/en/stable/ref/settings/ for the full list.
 """
 
 from pathlib import Path
+from typing import Any
 
 from dotenv import dotenv_values
 
@@ -48,7 +49,7 @@ ROOT_URLCONF = "openmv.urls"
 
 # `OPTIONS.debug` is set per-environment in dev.py / prod.py, after this
 # import, so the template debug toolbar tracks the real DEBUG flag.
-TEMPLATES = [
+TEMPLATES: list[dict[str, Any]] = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [],

--- a/openmv/settings/base.py
+++ b/openmv/settings/base.py
@@ -1,5 +1,9 @@
 """
-Django settings for the openmv project.
+Shared Django settings for the openmv project.
+
+`dev.py` and `prod.py` import from here and add the per-environment
+DEBUG / DATABASES / ALLOWED_HOSTS / proxy-header bits. Pick which one
+to use via DJANGO_SETTINGS_MODULE (defaults to openmv.settings.dev).
 
 See https://docs.djangoproject.com/en/stable/topics/settings/ for an overview
 and https://docs.djangoproject.com/en/stable/ref/settings/ for the full list.
@@ -9,35 +13,15 @@ from pathlib import Path
 
 from dotenv import dotenv_values
 
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 dotenv_file = BASE_DIR / ".env"
 assert Path(dotenv_file).parent.exists(), f"{dotenv_file} directory does not exist"
 assert Path(dotenv_file).exists(), f"{dotenv_file} does not exist"
 
-# Build paths inside the project like this: BASE_DIR / 'subdir'.
-
-
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = dotenv_values(dotenv_path=dotenv_file).get("SECRET_KEY", None)
 assert SECRET_KEY is not None
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = bool(int(dotenv_values(dotenv_path=dotenv_file).get("DJANGO_DEBUG", None)))
-
-ALLOWED_HOSTS = [".openmv.net", "127.0.0.1"]
-
-# Caddy terminates TLS on the host and proxies plain HTTP to gunicorn.
-# This header tells Django the request was originally HTTPS.
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-
-# Required by Django 4.x for any non-GET request (e.g. admin login) when the
-# request reaches Django over HTTPS via a reverse proxy.
-CSRF_TRUSTED_ORIGINS = [
-    "https://openmv.net",
-    "https://www.openmv.net",
-    "https://test.openmv.net",
-]
 
 # Application definition
 INSTALLED_APPS = [
@@ -62,13 +46,15 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = "openmv.urls"
 
+# `OPTIONS.debug` is set per-environment in dev.py / prod.py, after this
+# import, so the template debug toolbar tracks the real DEBUG flag.
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [],
         "APP_DIRS": True,
         "OPTIONS": {
-            "debug": DEBUG,
+            "debug": False,
             "context_processors": [
                 "django.template.context_processors.debug",
                 "django.template.context_processors.request",
@@ -81,35 +67,6 @@ TEMPLATES = [
 
 
 WSGI_APPLICATION = "openmv.wsgi.application"
-
-# Database
-# https://docs.djangoproject.com/en/stable/ref/settings/#databases
-
-if DEBUG:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": BASE_DIR / "db.sqlite3",
-        }
-    }
-else:
-    keys = ["POSTGRES_DB", "POSTGRES_USER", "POSTGRES_PASSWORD", "SQL_HOST", "SQL_PORT"]
-    db_settings = {}
-    for key in keys:
-        value = dotenv_values(dotenv_path=dotenv_file).get(key, None)
-        assert value is not None, f"{key} is not set in the .env file"
-        db_settings[key] = value
-
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.postgresql",
-            "NAME": db_settings["POSTGRES_DB"],
-            "USER": db_settings["POSTGRES_USER"],
-            "PASSWORD": db_settings["POSTGRES_PASSWORD"],
-            "HOST": db_settings["SQL_HOST"],
-            "PORT": db_settings["SQL_PORT"],
-        }
-    }
 
 
 # Password validation
@@ -150,7 +107,7 @@ STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / STATIC_URL.strip("/")
 
 # Media files (admin-uploaded dataset CSV/XLS/XML/MAT files).
-# In production Apache serves /media/ directly; locally `runserver` only
+# In production Caddy serves /media/ directly; locally `runserver` only
 # serves it when openmv/urls.py wires up `static()` under DEBUG.
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"

--- a/openmv/settings/dev.py
+++ b/openmv/settings/dev.py
@@ -1,0 +1,17 @@
+"""Local-development settings: SQLite + DEBUG=True + runserver-friendly hosts."""
+
+from .base import *  # noqa: F401,F403
+from .base import BASE_DIR, TEMPLATES
+
+DEBUG = True
+
+TEMPLATES[0]["OPTIONS"]["debug"] = DEBUG
+
+ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}

--- a/openmv/settings/prod.py
+++ b/openmv/settings/prod.py
@@ -1,0 +1,40 @@
+"""Production settings: Postgres + DEBUG=False + Caddy/Cloudflare proxy headers."""
+
+from dotenv import dotenv_values
+
+from .base import *  # noqa: F401,F403
+from .base import dotenv_file
+
+DEBUG = False
+
+ALLOWED_HOSTS = [".openmv.net", "127.0.0.1"]
+
+# Caddy terminates TLS on the host and proxies plain HTTP to gunicorn.
+# This header tells Django the request was originally HTTPS.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+# Required by Django 4.x for any non-GET request (e.g. admin login) when the
+# request reaches Django over HTTPS via a reverse proxy.
+CSRF_TRUSTED_ORIGINS = [
+    "https://openmv.net",
+    "https://www.openmv.net",
+    "https://test.openmv.net",
+]
+
+_db_keys = ["POSTGRES_DB", "POSTGRES_USER", "POSTGRES_PASSWORD", "SQL_HOST", "SQL_PORT"]
+_db_settings = {}
+for _key in _db_keys:
+    _value = dotenv_values(dotenv_path=dotenv_file).get(_key, None)
+    assert _value is not None, f"{_key} is not set in the .env file"
+    _db_settings[_key] = _value
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": _db_settings["POSTGRES_DB"],
+        "USER": _db_settings["POSTGRES_USER"],
+        "PASSWORD": _db_settings["POSTGRES_PASSWORD"],
+        "HOST": _db_settings["SQL_HOST"],
+        "PORT": _db_settings["SQL_PORT"],
+    }
+}

--- a/openmv/wsgi.py
+++ b/openmv/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openmv.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "openmv.settings.dev")
 
 application = get_wsgi_application()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,6 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-DJANGO_SETTINGS_MODULE = "openmv.settings"
+DJANGO_SETTINGS_MODULE = "openmv.settings.dev"
 python_files = ["tests.py", "test_*.py", "*_tests.py"]
 addopts = "-ra"


### PR DESCRIPTION
Closes #5 and #11.

## Issue #5 — `DatasetManager.get_query_set` → `get_queryset`

Drops the legacy pre-Django-1.6 method name so the `is_hidden=False` filter actually runs. Per discussion during planning, this is the minimal rename only — no `all_objects` manager, no admin override. Hidden datasets therefore disappear from the public site **and** from the admin list; to re-edit one, flip `is_hidden` directly via `manage.py shell` or `psql`.

### ⚠ Pre-merge action for the site owner

Issue #5's acceptance criteria require a manual review of currently-hidden datasets before merging. From the production DB:

```sql
SELECT slug, name FROM datasetapp_dataset WHERE is_hidden = true;
```

Confirm each row is *meant* to be hidden. If any were marked hidden by mistake, flip `is_hidden=False` before this PR ships, otherwise they will vanish from the live homepage.

## Issue #11 — Split `openmv/settings.py` into `base/dev/prod`

`openmv/settings.py` becomes a package:

- `openmv/settings/base.py` — shared (apps, middleware, templates, auth, i18n, static/media, the `.env` assertion).
- `openmv/settings/dev.py` — `DEBUG=True`, SQLite, `ALLOWED_HOSTS=['127.0.0.1', 'localhost']`.
- `openmv/settings/prod.py` — `DEBUG=False`, Postgres, `ALLOWED_HOSTS=['.openmv.net', '127.0.0.1']`, plus the existing `SECURE_PROXY_SSL_HEADER` + `CSRF_TRUSTED_ORIGINS` for Caddy.

`manage.py` / `wsgi.py` / `asgi.py` / `pytest` default to `openmv.settings.dev`. `docker-compose.prod.yml` sets `DJANGO_SETTINGS_MODULE=openmv.settings.prod` on the `web` service so prod never falls back to the local default. `docker-compose.yml` (local Docker dev) drops the Postgres `db` service and just runs runserver against SQLite — true prod parity stays the job of `docker-compose.prod.yml`.

`DJANGO_DEBUG` is no longer read anywhere. `.env.example`, the CI stub `.env`, README, and CLAUDE.md are all updated.

**Behaviour on the live site is unchanged at first deploy** — `prod.py` carries forward exactly the existing settings (no new security headers; those land in a follow-up issue, per the acceptance criterion).

## Test plan

- [x] `DJANGO_SETTINGS_MODULE=openmv.settings.dev manage.py check` — passes.
- [x] `DJANGO_SETTINGS_MODULE=openmv.settings.prod manage.py check` (with all `POSTGRES_*` / `SQL_*` keys present) — passes.
- [x] `uv run pytest` — 9/9 pass.
- [x] `uv run pre-commit run --all-files` — passes.
- [ ] Site owner reviews `SELECT slug, name FROM datasetapp_dataset WHERE is_hidden = true;` on the prod DB before merging (Issue #5 gate).
- [ ] After auto-deploy: `https://openmv.net/` and `https://test.openmv.net/` still load, admin login still works (proves prod's CSRF / proxy header are wired), `DEBUG` is off (no detailed error pages).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVdQPdK4q5kMBG1SXAQQAR)_