### PR TITLE
Move right-click hint next to the download link

### DIFF
--- a/datasetapp/templates/datasetapp/dataset_info.html
+++ b/datasetapp/templates/datasetapp/dataset_info.html
@@ -26,6 +26,7 @@
         <a class="download-cta" href="{% url 'datasetapp:dataset-download' file_name=download_file_name %}">
             Download <span class="download-cta__type">{{ dfile.file_type }}</span>
         </a>
+        <p class="download-hint">(Right-click link; choose "<i>Save Link As</i>")</p>
         <p class="download-meta">{{ num_hits }} download{{ num_hits|pluralize }}</p>
 
         {% if num_hits %}
@@ -67,8 +68,6 @@
         })();
         </script>
         {% endif %}
-
-        <p class="download-hint">(Right-click link; choose "<i>Save Link As</i>")</p>
 
         <div class="tag-section">
             <p class="eyebrow">Tags for this dataset</p>


### PR DESCRIPTION
## Summary
- The "(Right-click link; choose *Save Link As*)" hint was rendering after the download counter and 365-day sparkline, far below the Download button it refers to.
- Move the hint to sit directly under the download link so the instruction is adjacent to the link it describes.

## Test plan
- [ ] Visit a dataset detail page (e.g. `/info/aeration-rate`) and confirm the right-click hint now appears between the Download button and the download count.
- [ ] Confirm the sparkline and tags still render correctly below.

https://claude.ai/code/session_017Fh6Y3Wph2bWWi8nTS1Yhu

---
_Generated by [Claude Code](https://claude.ai/code/session_017Fh6Y3Wph2bWWi8nTS1Yhu)_