### PR TITLE
Read settings from os.environ first; ALLOWED_HOSTS from env (#22, #23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,18 @@
-# Copy this file to `.env` and fill in real values. The Django settings module
-# refuses to start if `.env` is missing.
+# Copy this file to `.env` and fill in real values, OR set the same keys
+# directly in the process environment (e.g. via Docker / systemd / CI).
+#
+# Settings read os.environ first, then fall back to `.env`, so a `.env` file
+# is no longer required when env vars are supplied another way. Only
+# SECRET_KEY is mandatory; everything else has sensible defaults.
 
 # Random string used for cryptographic signing. Generate with:
 #   python -c "import secrets; print(secrets.token_urlsafe(50))"
 SECRET_KEY=change-me
+
+# Comma-separated hostnames Django will accept. Defaults to
+# `127.0.0.1,localhost` in dev and `.openmv.net,127.0.0.1` in prod.
+# Override only when deploying under a different hostname.
+#ALLOWED_HOSTS=.openmv.net,127.0.0.1
 
 # Postgres connection details. Only consulted by `openmv.settings.prod`;
 # `openmv.settings.dev` uses SQLite.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,18 +20,10 @@ jobs:
       - name: Install dependencies (locked)
         run: uv sync --frozen
 
-      # `openmv/settings/base.py` asserts that .env exists at import time, so
-      # the test runner blows up without one. Synthesize a minimal .env here.
-      # TODO: drop this once settings reads from os.environ first.
-      # Tracked in the "stop asserting .env exists" follow-up issue.
-      - name: Create stub .env for tests
-        run: |
-          cat > .env <<'EOF'
-          SECRET_KEY=ci-test-key
-          EOF
-
       - name: Lint (pre-commit)
         run: uv run pre-commit run --all-files --show-diff-on-failure --color always
 
       - name: Test (pytest)
         run: uv run pytest
+        env:
+          SECRET_KEY: ci-test-key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,10 @@ The Django site behind <https://openmv.net> — a dataset catalogue that lists, 
 ## How it runs
 
 - `make debug` runs `collectstatic --no-input`, `migrate`, `createcachetable`, then `runserver 8080 --nostatic`.
-- Settings load `.env` via `python-dotenv`'s `dotenv_values()`. The file is **required** — `openmv/settings/base.py` asserts it exists on import (CI synthesises a stub).
+- Settings read **process environment first**, then fall back to a `.env` file via `python-dotenv` if one exists. The `env()` and `env_list()` helpers in `openmv/settings/base.py` encapsulate this. `SECRET_KEY` is the only universally required key; `prod.py` additionally requires the `POSTGRES_*` + `SQL_*` keys. Either layer (env or `.env`) can supply them — handy for containers, CI, and ad-hoc overrides.
 - Which DB / hosts / DEBUG flag you get depends on `DJANGO_SETTINGS_MODULE`:
-  - `openmv.settings.dev` (default in `manage.py`, `wsgi.py`, `asgi.py`, `pyproject.toml` pytest) → SQLite at `db.sqlite3`, `DEBUG=True`, `ALLOWED_HOSTS=['127.0.0.1', 'localhost']`.
-  - `openmv.settings.prod` (forced by `docker-compose.prod.yml`'s `web.environment` block) → Postgres via `POSTGRES_*` + `SQL_*` keys, `DEBUG=False`, `ALLOWED_HOSTS=['.openmv.net', '127.0.0.1']`, `SECURE_PROXY_SSL_HEADER` + `CSRF_TRUSTED_ORIGINS` for Caddy.
+  - `openmv.settings.dev` (default in `manage.py`, `wsgi.py`, `asgi.py`, `pyproject.toml` pytest) → SQLite at `db.sqlite3`, `DEBUG=True`, `ALLOWED_HOSTS` from `$ALLOWED_HOSTS` (default `127.0.0.1,localhost`).
+  - `openmv.settings.prod` (forced by `docker-compose.prod.yml`'s `web.environment` block) → Postgres via `POSTGRES_*` + `SQL_*` keys, `DEBUG=False`, `ALLOWED_HOSTS` from `$ALLOWED_HOSTS` (default `.openmv.net,127.0.0.1`), `SECURE_PROXY_SSL_HEADER` + `CSRF_TRUSTED_ORIGINS` for Caddy.
 
 ## Running locally
 
@@ -74,7 +74,7 @@ Cloudflare (proxied, orange cloud) ──HTTPS──> Caddy on Hetzner host (TLS
   - `media/` — Django uploads served by Caddy and mounted into the container as `/app/media`.
   - `static/` — `collectstatic` output, mounted as `/app/static`. Re-populated by the `web` container's startup command.
   - `public/` — host the small files Apache used to alias (`robots.txt`, `favicon.ico`, `blender-efficiency.xlsx`).
-- **`.env`** is **bind-mounted** into the container (`./.env:/app/.env:ro`) because `openmv/settings/base.py` reads the file at import time and `.dockerignore` excludes it from the image. Never commit `.env`.
+- **`.env`** is **bind-mounted** into the container (`./.env:/app/.env:ro`) so `openmv/settings/base.py` finds it on import. Settings now read process env first, so an alternative is to drop the bind-mount and set the same keys in `web.environment` directly — but the bind-mount is currently the simpler path because it keeps the `POSTGRES_*` / `SQL_*` / `SECRET_KEY` config in one place. Never commit `.env`.
 - **`DJANGO_SETTINGS_MODULE=openmv.settings.prod`** is set on the `web` service in `docker-compose.prod.yml`; this is what selects the prod-only DB / hosts / proxy headers. Don't rely on the `manage.py` default for production.
 - **Caddy config**: `/etc/caddy/Caddyfile` on the host. Reload with `sudo systemctl reload caddy` (validate first with `sudo caddy validate --config /etc/caddy/Caddyfile`).
 - **TLS**:
@@ -101,7 +101,7 @@ Cloudflare (proxied, orange cloud) ──HTTPS──> Caddy on Hetzner host (TLS
   - Refresh the lockfile after manual edits: `uv lock`
   - Django is pinned `>=4.2,<5.0` until 5.x has been smoke-tested on staging.
 - **Tests** run with `uv run pytest` (or `make test`). `pytest-django` is wired through `[tool.pytest.ini_options]` in `pyproject.toml`. Smoke suite lives in `datasetapp/tests/test_views.py`.
-- **GitHub Actions** runs `pre-commit run --all-files` and `pytest` on every PR and on push to `master` (`.github/workflows/ci.yml`). The job synthesizes a stub `.env` because `openmv/settings/base.py` asserts one exists at import — see the "stop asserting `.env` exists" follow-up issue.
+- **GitHub Actions** runs `pre-commit run --all-files` and `pytest` on every PR and on push to `master` (`.github/workflows/ci.yml`). The pytest step injects `SECRET_KEY` directly via the workflow `env:` block — no `.env` file is created.
 - **Docker compose**: `docker-compose.yml` is for **local development** (volume-mounts the source for hot reload, runs `runserver` against SQLite via `openmv.settings.dev`). `docker-compose.prod.yml` is the **production** compose used on Hetzner (bind-mounts `.env` and `data/` dirs, sets `DJANGO_SETTINGS_MODULE=openmv.settings.prod`, runs `migrate` + `collectstatic` + `gunicorn`, binds to loopback on offset ports `8001`/`5434`). Both use the same `Dockerfile`.
 - **pre-commit** is configured (`.pre-commit-config.yaml`) — hooks are kept on current stable releases (`pre-commit-hooks` v5, `mypy` v1.13, `isort` 5.13, `black` 24.10, `blacken-docs` 1.19, `flake8` 7.1). Refresh with `pre-commit autoupdate` and re-run `pre-commit run --all-files` before merging.
 - **flake8** config: `.flake8`. Line length 100. Ignores E266/E203/E231/W503.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ uv sync --dev
 cp .env.example .env
 # Edit .env: set SECRET_KEY to any random string. The Postgres keys are
 # only consulted by openmv.settings.prod, so they can stay as the
-# placeholders for local dev.
+# placeholders for local dev. (Settings read process env first, so you
+# can also export SECRET_KEY directly and skip the .env file entirely.)
 
 # 4. Run the dev server (collectstatic + migrate + createcachetable + runserver:8080)
 make debug
@@ -92,8 +93,8 @@ Create a superuser with `uv run python manage.py createsuperuser` (native) or `d
 
 ## Production notes
 
-- Production sets `DJANGO_SETTINGS_MODULE=openmv.settings.prod` (wired in `docker-compose.prod.yml`), which selects PostgreSQL via `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `SQL_HOST`, `SQL_PORT` from `.env` and turns off `DEBUG`.
-- `ALLOWED_HOSTS` is hardcoded to `.openmv.net` and `127.0.0.1` in `openmv/settings/prod.py`. Change it there for other deployments.
+- Production sets `DJANGO_SETTINGS_MODULE=openmv.settings.prod` (wired in `docker-compose.prod.yml`), which selects PostgreSQL via `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `SQL_HOST`, `SQL_PORT` from the environment (or `.env`) and turns off `DEBUG`. Settings read process environment first, then fall back to `.env`, so containers/CI can inject config directly.
+- `ALLOWED_HOSTS` reads from the `ALLOWED_HOSTS` env var (comma-separated). Defaults: `.openmv.net,127.0.0.1` in prod, `127.0.0.1,localhost` in dev. Override the env var to deploy under a different hostname.
 - Static files land in `BASE_DIR / 'static'` after `python manage.py collectstatic`. Admin-uploaded dataset files land in `BASE_DIR / 'media'` (`MEDIA_ROOT`), reachable at `/media/` (`MEDIA_URL`). The live site has Apache serving `/static/` and `/media/` directly; the `download_dataset` view returns a 302 to the `/media/...` URL rather than streaming the file through Django. Locally, `runserver` serves `/media/` only when `DJANGO_DEBUG=1` (see `openmv/urls.py`); in production Apache must be configured to intercept `/media/` before the request reaches Django.
 - The `Hit` table grows with every download. There is no automatic pruning.
 

--- a/openmv/settings/base.py
+++ b/openmv/settings/base.py
@@ -9,6 +9,7 @@ See https://docs.djangoproject.com/en/stable/topics/settings/ for an overview
 and https://docs.djangoproject.com/en/stable/ref/settings/ for the full list.
 """
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -16,13 +17,33 @@ from dotenv import dotenv_values
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
-dotenv_file = BASE_DIR / ".env"
-assert Path(dotenv_file).parent.exists(), f"{dotenv_file} directory does not exist"
-assert Path(dotenv_file).exists(), f"{dotenv_file} does not exist"
+# Read configuration from process environment first, then fall back to a `.env`
+# file if present. This lets containers / CI inject config directly without
+# needing to write a `.env`, while keeping the file-based workflow for local dev.
+_dotenv_path = BASE_DIR / ".env"
+_dotenv = dotenv_values(dotenv_path=_dotenv_path) if _dotenv_path.exists() else {}
+
+
+def env(key: str, default: str | None = None) -> str | None:
+    """Read a config value from os.environ, falling back to .env, then default."""
+    value = os.environ.get(key)
+    if value is not None:
+        return value
+    value = _dotenv.get(key)
+    if value is not None:
+        return value
+    return default
+
+
+def env_list(key: str, default: str) -> list[str]:
+    """Read a comma-separated env value as a list of stripped, non-empty entries."""
+    raw = env(key, default) or ""
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = dotenv_values(dotenv_path=dotenv_file).get("SECRET_KEY", None)
-assert SECRET_KEY is not None
+SECRET_KEY = env("SECRET_KEY")
+assert SECRET_KEY, "SECRET_KEY must be set via environment variable or .env file"
 
 # Application definition
 INSTALLED_APPS = [

--- a/openmv/settings/dev.py
+++ b/openmv/settings/dev.py
@@ -1,13 +1,13 @@
 """Local-development settings: SQLite + DEBUG=True + runserver-friendly hosts."""
 
 from .base import *  # noqa: F401,F403
-from .base import BASE_DIR, TEMPLATES
+from .base import BASE_DIR, TEMPLATES, env_list
 
 DEBUG = True
 
 TEMPLATES[0]["OPTIONS"]["debug"] = DEBUG
 
-ALLOWED_HOSTS = ["127.0.0.1", "localhost"]
+ALLOWED_HOSTS = env_list("ALLOWED_HOSTS", "127.0.0.1,localhost")
 
 DATABASES = {
     "default": {

--- a/openmv/settings/prod.py
+++ b/openmv/settings/prod.py
@@ -1,13 +1,11 @@
 """Production settings: Postgres + DEBUG=False + Caddy/Cloudflare proxy headers."""
 
-from dotenv import dotenv_values
-
 from .base import *  # noqa: F401,F403
-from .base import dotenv_file
+from .base import env, env_list
 
 DEBUG = False
 
-ALLOWED_HOSTS = [".openmv.net", "127.0.0.1"]
+ALLOWED_HOSTS = env_list("ALLOWED_HOSTS", ".openmv.net,127.0.0.1")
 
 # Caddy terminates TLS on the host and proxies plain HTTP to gunicorn.
 # This header tells Django the request was originally HTTPS.
@@ -24,8 +22,10 @@ CSRF_TRUSTED_ORIGINS = [
 _db_keys = ["POSTGRES_DB", "POSTGRES_USER", "POSTGRES_PASSWORD", "SQL_HOST", "SQL_PORT"]
 _db_settings = {}
 for _key in _db_keys:
-    _value = dotenv_values(dotenv_path=dotenv_file).get(_key, None)
-    assert _value is not None, f"{_key} is not set in the .env file"
+    _value = env(_key)
+    assert (
+        _value is not None
+    ), f"{_key} must be set via environment variable or .env file"
     _db_settings[_key] = _value
 
 DATABASES = {


### PR DESCRIPTION
## Summary

Implements **batch C2** of the modernization roadmap (#42): env-first config (#22) + `ALLOWED_HOSTS` from env (#23). Both batched together because they share the same plumbing.

- Adds `env()` and `env_list()` helpers to `openmv/settings/base.py` that read from `os.environ` first and fall back to `.env` if it exists. Drops the import-time `assert .env exists` checks. `SECRET_KEY` is the only universally required key.
- `ALLOWED_HOSTS` now reads from `$ALLOWED_HOSTS` (comma-separated) in both `dev.py` and `prod.py`, with the previous defaults preserved (`127.0.0.1,localhost` for dev; `.openmv.net,127.0.0.1` for prod).
- `prod.py` now uses the same `env()` helper for the Postgres / SQL keys, so they can come from either `.env` or container env vars (which is how `docker-compose.prod.yml` already passes them).
- Drops the "Create stub .env for tests" step from `.github/workflows/ci.yml`. The pytest step now sets `SECRET_KEY` directly via the workflow `env:` block.
- `CLAUDE.md` and `README.md` updated to reflect the new env-first behaviour.

This unblocks the rest of batch C in #42 (C3 production hardening, C4 Postgres in CI).

## Backwards compatibility

- Existing `.env` files keep working unchanged.
- The bind-mounted `.env` in `docker-compose.prod.yml` still loads — production deploy is unaffected at first apply.
- Hardcoded defaults in `dev.py` / `prod.py` match the previous values, so behaviour is identical when no `ALLOWED_HOSTS` env var is set.

## Test plan

- [x] `uv run pytest` passes with `SECRET_KEY` from env and **no `.env`** file present (9/9 tests).
- [x] `DJANGO_SETTINGS_MODULE=openmv.settings.prod manage.py check` passes when all required keys come from env vars only — no `.env` involved.
- [x] `ALLOWED_HOSTS=example.test,foo.test` overrides the default at runtime.
- [x] Default `ALLOWED_HOSTS` (no env var) still resolves to `['127.0.0.1', 'localhost']` in dev.
- [x] Missing `SECRET_KEY` still raises `AssertionError` with a clear message.
- [x] `pre-commit run --all-files` clean (mypy / black / flake8 / isort all pass).
- [ ] CI passes on this PR.
- [ ] Hetzner auto-deploy after merge: `web` container boots, gunicorn responds on `127.0.0.1:8001`, homepage renders.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fgq7KAPpPrPDk4vGHWCMHJ)_