### PR TITLE
Run CI tests against Postgres 16 (closes #30, #42 C4) + version-bump policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: openmv
+          POSTGRES_USER: openmv
+          POSTGRES_PASSWORD: openmv
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
 
@@ -27,3 +42,9 @@ jobs:
         run: uv run pytest
         env:
           SECRET_KEY: ci-test-key
+          DJANGO_SETTINGS_MODULE: openmv.settings.ci
+          POSTGRES_DB: openmv
+          POSTGRES_USER: openmv
+          POSTGRES_PASSWORD: openmv
+          SQL_HOST: 127.0.0.1
+          SQL_PORT: "5432"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ The Django site behind <https://openmv.net> — a dataset catalogue that lists, 
 
 ## Project shape
 
-- **Project**: `openmv/` (settings package, URL conf, WSGI/ASGI). Settings live under `openmv/settings/` — `base.py` (shared), `dev.py` (local SQLite + DEBUG=True), `prod.py` (Postgres + DEBUG=False + Caddy proxy headers).
+- **Project**: `openmv/` (settings package, URL conf, WSGI/ASGI). Settings live under `openmv/settings/` — `base.py` (shared), `dev.py` (local SQLite + DEBUG=True), `prod.py` (Postgres + DEBUG=False + Caddy proxy headers), `ci.py` (GitHub Actions — derives from `prod.py` and disables HTTPS-only middleware so the Django test client works).
 - **App**: `datasetapp/` (the only app).
 - **Models** (`datasetapp/models.py`): `Tag`, `Dataset`, `DataFile`, `Hit`.
   - `Dataset` ↔ `Tag` is many-to-many.
@@ -35,6 +35,7 @@ The Django site behind <https://openmv.net> — a dataset catalogue that lists, 
 - Which DB / hosts / DEBUG flag you get depends on `DJANGO_SETTINGS_MODULE`:
   - `openmv.settings.dev` (default in `manage.py`, `wsgi.py`, `asgi.py`, `pyproject.toml` pytest) → SQLite at `db.sqlite3`, `DEBUG=True`, `ALLOWED_HOSTS` from `$ALLOWED_HOSTS` (default `127.0.0.1,localhost`).
   - `openmv.settings.prod` (forced by `docker-compose.prod.yml`'s `web.environment` block) → Postgres via `POSTGRES_*` + `SQL_*` keys, `DEBUG=False`, `ALLOWED_HOSTS` from `$ALLOWED_HOSTS` (default `.openmv.net,127.0.0.1`), `SECURE_PROXY_SSL_HEADER` + `CSRF_TRUSTED_ORIGINS` for Caddy.
+  - `openmv.settings.ci` (forced by `.github/workflows/ci.yml` for the pytest step) → re-exports prod, then turns off `SECURE_SSL_REDIRECT` / HSTS / secure-cookie flags so the Django test client (which uses HTTP) doesn't hit a 301. Same Postgres `POSTGRES_*` + `SQL_*` env vars as prod, supplied by the workflow against the `postgres:16-alpine` service.
 
 ## Running locally
 
@@ -101,7 +102,7 @@ Cloudflare (proxied, orange cloud) ──HTTPS──> Caddy on Hetzner host (TLS
   - Refresh the lockfile after manual edits: `uv lock`
   - Django is pinned `>=4.2,<5.0` until 5.x has been smoke-tested on staging.
 - **Tests** run with `uv run pytest` (or `make test`). `pytest-django` is wired through `[tool.pytest.ini_options]` in `pyproject.toml`. Smoke suite lives in `datasetapp/tests/test_views.py`.
-- **GitHub Actions** runs `pre-commit run --all-files` and `pytest` on every PR and on push to `master` (`.github/workflows/ci.yml`). The pytest step injects `SECRET_KEY` directly via the workflow `env:` block — no `.env` file is created.
+- **GitHub Actions** runs `pre-commit run --all-files` and `pytest` on every PR and on push to `master` (`.github/workflows/ci.yml`). The pytest step boots a `postgres:16-alpine` service container, sets `DJANGO_SETTINGS_MODULE=openmv.settings.ci`, and injects `SECRET_KEY` + `POSTGRES_*` + `SQL_*` env vars directly via the workflow `env:` block — no `.env` file is created. Tests therefore run against the same database engine as production, catching Postgres-only behaviour that SQLite would silently paper over.
 - **Docker compose**: `docker-compose.yml` is for **local development** (volume-mounts the source for hot reload, runs `runserver` against SQLite via `openmv.settings.dev`). `docker-compose.prod.yml` is the **production** compose used on Hetzner (bind-mounts `.env` and `data/` dirs, sets `DJANGO_SETTINGS_MODULE=openmv.settings.prod`, runs `migrate` + `collectstatic` + `gunicorn`, binds to loopback on offset ports `8001`/`5434`). Both use the same `Dockerfile`.
 - **pre-commit** is configured (`.pre-commit-config.yaml`) — hooks are kept on current stable releases (`pre-commit-hooks` v5, `mypy` v1.13, `isort` 5.13, `black` 24.10, `blacken-docs` 1.19, `flake8` 7.1). Refresh with `pre-commit autoupdate` and re-run `pre-commit run --all-files` before merging.
 - **flake8** config: `.flake8`. Line length 100. Ignores E266/E203/E231/W503.
@@ -111,10 +112,36 @@ Cloudflare (proxied, orange cloud) ──HTTPS──> Caddy on Hetzner host (TLS
 - Production deploys ship from `master`.
 - Modernization work happens on `claude/modernize-legacy-repo-*` branches and is reviewed before merge.
 
+## Versioning and releases
+
+Every PR that changes runtime behaviour, dependencies, settings, CI, deploy
+scripts, or public docs **must** bump `version` in `pyproject.toml` and add a
+matching `## v<new-version>` section to `RELEASES.md` describing the change.
+The version field is the trigger for the release pipeline — no bump means no
+release.
+
+Bump heuristic (anchors the policy stated in the v1.0.0 release notes):
+
+- **PATCH** (`x.y.Z`) — bugfixes, dependency security bumps, infra-only
+  tweaks with no user-visible behaviour change.
+- **MINOR** (`x.Y.0`) — additive features, schema additions, new templates,
+  new settings modules, CI parity work (e.g. Postgres-in-CI).
+- **MAJOR** (`X.0.0`) — URL or template structure breaks, removal of public
+  views, anything that could surprise an unsuspecting visitor.
+
+If unsure which level to pick, **ask the human reviewer before merging.** When
+running as Claude Code, ask via `AskUserQuestion` rather than guessing.
+
+Tagging and the GitHub Release are produced automatically by
+`.github/workflows/release.yml` once the bumped `pyproject.toml` and the
+matching `RELEASES.md` section land on `master`. The workflow refuses to run
+if the `## v<version>` heading is missing — that's the safety net. **Do not**
+create tags manually.
+
 ## Outstanding work
 
 The GitHub issue tracker is the single source of truth for outstanding work: <https://github.com/kgdunn/Django-dataset-download-app/issues>. Don't duplicate the list here — it goes stale.
 
 ## Keeping this file consistent
 
-CLAUDE.md must stay consistent with the codebase. On any PR that touches `datasetapp/`, `openmv/`, `pyproject.toml`, `Makefile`, `.pre-commit-config.yaml`, or `.github/workflows/`, re-read this file before opening the PR and update anything that has drifted — Project shape, How it runs, Gotchas, Tooling, Branch conventions. If you're Claude Code, run this consistency check on every implementation task, not just when explicitly asked.
+CLAUDE.md must stay consistent with the codebase. On any PR that touches `datasetapp/`, `openmv/`, `pyproject.toml`, `RELEASES.md`, `Makefile`, `.pre-commit-config.yaml`, or `.github/workflows/`, re-read this file before opening the PR and update anything that has drifted — Project shape, How it runs, Gotchas, Tooling, Branch conventions, Versioning and releases. If you're Claude Code, run this consistency check on every implementation task, not just when explicitly asked.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,28 @@
 # Releases
 
+## v1.1.0
+
+CI now runs the test suite against Postgres 16 to match production, closing
+the C4 item on the modernization roadmap (#42).
+
+### Highlights
+
+- **Postgres in CI** (#30): `.github/workflows/ci.yml` boots a
+  `postgres:16-alpine` service container and points pytest at a new
+  `openmv.settings.ci` module. The new module derives from `prod.py` —
+  Postgres engine, `DEBUG=False`, the same `POSTGRES_*` + `SQL_*` env-var
+  contract — but disables `SECURE_SSL_REDIRECT`, HSTS, and the
+  secure-cookie flags so the Django test client (which speaks plain HTTP)
+  doesn't get 301-redirected on every request. Postgres-only behaviour
+  (datatypes, transaction semantics, parameter quoting, migrations) is now
+  exercised by the smoke suite on every push and PR.
+- **Versioning policy**: CLAUDE.md gains a "Versioning and releases"
+  section codifying the every-PR `pyproject.toml` + `RELEASES.md` bump
+  rule, the patch/minor/major heuristic, and the requirement to ask the
+  human reviewer (or `AskUserQuestion` when running as Claude Code) when
+  unsure. Tag + GitHub Release continue to be produced automatically by
+  `release.yml`.
+
 ## v1.0.0
 
 First tagged release. Captures the 2026 modernization of the long-standing

--- a/openmv/settings/ci.py
+++ b/openmv/settings/ci.py
@@ -1,0 +1,14 @@
+"""CI settings: prod-like (Postgres, DEBUG=False) but test-client friendly.
+
+Imports prod, then disables the HTTPS-only middleware behaviour that would
+otherwise 301-redirect every Django test client request, since the test
+client speaks plain HTTP. Used by .github/workflows/ci.yml so pytest runs
+against the same database engine production uses.
+"""
+
+from .prod import *  # noqa: F401,F403
+
+SECURE_SSL_REDIRECT = False
+SECURE_HSTS_SECONDS = 0
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.0.0"
+version = "1.1.0"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "openmv"
-version = "1.0.0"
+version = "1.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Summary

- Closes the C4 item on the modernization roadmap (#42) by addressing #30: pytest in CI now runs against `postgres:16-alpine` instead of SQLite, so Postgres-only behaviour is exercised on every push and PR. A new `openmv/settings/ci.py` module re-exports `prod.py` (Postgres + `DEBUG=False` + the existing `POSTGRES_*` / `SQL_*` env-var contract) and only flips off the HTTPS-only middleware flags so the Django test client (HTTP) doesn't get 301-redirected.
- Documents the every-PR version-bump rule in `CLAUDE.md` under a new "Versioning and releases" section, with a patch/minor/major heuristic and an explicit "ask the human reviewer if unsure" clause. The existing `release.yml` already auto-tags and publishes from `pyproject.toml` + `RELEASES.md`, so no new workflow is needed.
- Bumps to **v1.1.0** with a matching `## v1.1.0` section in `RELEASES.md`, which `release.yml` will pick up on merge to master and turn into the `v1.1.0` tag + GitHub Release automatically.

## Files changed

- `openmv/settings/ci.py` *(new)* — prod-derived; disables `SECURE_SSL_REDIRECT`, HSTS, secure cookies.
- `.github/workflows/ci.yml` — adds `services.postgres` (`postgres:16-alpine` with `pg_isready` healthcheck on port 5432) and the matching `DJANGO_SETTINGS_MODULE` + `POSTGRES_*` / `SQL_*` env vars on the pytest step. Lint step unchanged.
- `CLAUDE.md` — Project shape, How it runs, Tooling now mention `ci.py` and the Postgres CI service. New "Versioning and releases" section codifies the bump policy. Consistency-check rule now lists `RELEASES.md`.
- `pyproject.toml` — `version = "1.0.0"` → `"1.1.0"`.
- `RELEASES.md` — new `## v1.1.0` section.

## Test plan

- [x] `pre-commit run --files <changed>` — all hooks pass locally.
- [x] Local import check: `DJANGO_SETTINGS_MODULE=openmv.settings.ci` reports `engine=postgresql`, `debug=False`, `ssl_redirect=False`, `hsts=0`, `session_secure=False`, `csrf_secure=False`.
- [ ] CI run on this PR: `Test (pytest)` step starts the postgres service container, passes `pg_isready`, and the existing smoke suite in `datasetapp/tests/test_views.py` is green against Postgres.
- [ ] After merge: `Release` workflow detects `version=1.1.0`, finds the `## v1.1.0` section, tags `v1.1.0`, and publishes the GitHub Release.

## Follow-ups

- Close issue #30 once this lands and tick the `C4` checkbox in the umbrella roadmap issue #42.

https://claude.ai/code/session_016DJfeoDYpiFCpaozTq4TfA

---
_Generated by [Claude Code](https://claude.ai/code/session_016DJfeoDYpiFCpaozTq4TfA)_