### PR TITLE
Add nightly S3 backup script (closes #49)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,11 @@ POSTGRES_USER=openmv
 POSTGRES_PASSWORD=change-me
 SQL_HOST=127.0.0.1
 SQL_PORT=5432
+
+# Off-host backups. Consumed by bin/backup-openmv.sh on the Hetzner host.
+# Leave blank in dev — the script is only run from the prod VPS.
+#AWS_ACCESS_KEY_ID=
+#AWS_SECRET_ACCESS_KEY=
+#AWS_DEFAULT_REGION=eu-central-1
+#BACKUP_S3_BUCKET=
+#BACKUP_S3_PREFIX=openmv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,91 @@ Cloudflare (proxied, orange cloud) ──HTTPS──> Caddy on Hetzner host (TLS
 - **Manual deploy** (rollback, hotfix, debugging): from `/home/deploy/openmv/repo/`, run `git pull && docker compose -f docker-compose.prod.yml up -d --build` directly.
 - **Public IPs**: IPv4 `178.104.167.195`, IPv6 `2a01:4f8:1c19:2380::1`. Behind Cloudflare's anycast for the apex; visible directly only for `test.openmv.net`.
 
+## Backups
+
+Off-host backups go to AWS S3 — deliberately a different cloud provider /
+account from the Hetzner VPS so a compromise of one doesn't reach the other.
+The Hetzner-side script is `bin/backup-openmv.sh`; it runs nightly under
+`deploy` from cron and does three things on every invocation:
+
+1. **Postgres dump** of the running `db` container via
+   `docker compose -f docker-compose.prod.yml exec -T db pg_dump --clean --if-exists`,
+   gzipped, uploaded to
+   `s3://$BACKUP_S3_BUCKET/$BACKUP_S3_PREFIX/db/daily/db_openmv-YYYY-MM-DD.sql.gz`.
+   The same dump is also copied to `db/monthly/db_openmv-YYYY-MM.sql.gz` on
+   the 1st of each month, and to `db/yearly/db_openmv-YYYY.sql.gz` on Jan 1.
+2. **`aws s3 sync`** of `data/media/` → `…/media/` and `data/public/` →
+   `…/public/`. No `--delete` flag — an accidental local rm or detached bind
+   mount must not propagate to the off-host copy. `data/static/` is
+   intentionally **not** backed up because `collectstatic` regenerates it on
+   every container start.
+3. **Retention pruning** by S3 `LastModified`: `db/daily/` keeps the 15
+   most recent objects, `db/monthly/` keeps 12, `db/yearly/` is never pruned.
+
+S3 layout:
+
+```
+s3://$BACKUP_S3_BUCKET/$BACKUP_S3_PREFIX/
+├── db/
+│   ├── daily/    db_openmv-2026-05-04.sql.gz   (≤15)
+│   ├── monthly/  db_openmv-2026-05.sql.gz      (≤12)
+│   └── yearly/   db_openmv-2026.sql.gz         (∞)
+├── media/        mirror of data/media/
+└── public/       mirror of data/public/
+```
+
+### Configuration
+
+`bin/backup-openmv.sh` sources the same `.env` the prod stack uses. The
+keys it needs on top of the existing `POSTGRES_*` set:
+
+```
+AWS_ACCESS_KEY_ID=…
+AWS_SECRET_ACCESS_KEY=…
+AWS_DEFAULT_REGION=eu-central-1
+BACKUP_S3_BUCKET=openmv-backups
+BACKUP_S3_PREFIX=openmv
+```
+
+The IAM principal those keys belong to should be scoped to `s3:PutObject`,
+`s3:GetObject`, `s3:DeleteObject`, and `s3:ListBucket` on
+`arn:aws:s3:::$BACKUP_S3_BUCKET/$BACKUP_S3_PREFIX/*` only — nothing else.
+Enable bucket versioning + SSE-S3 (default since Jan 2023) when creating
+the bucket.
+
+### Host prerequisite
+
+The Hetzner VPS needs the AWS CLI on the host (not in the container — the
+script calls `aws` directly). One-shot: `sudo apt install awscli`.
+
+### Cron entry (run as `deploy`)
+
+```
+35 21 * * *  /home/deploy/openmv/repo/bin/backup-openmv.sh \
+    >> /home/deploy/openmv/backups/backup.log 2>&1
+```
+
+Same time the Linode cron used to run. The script is *not* installed
+automatically by `bin/deploy-impl.sh`; cron lives outside the repo because
+its presence and schedule are operational state, not application state.
+
+### Restore
+
+```bash
+# Database (daily snapshot)
+aws s3 cp s3://$BACKUP_S3_BUCKET/openmv/db/daily/db_openmv-YYYY-MM-DD.sql.gz - \
+  | gunzip \
+  | docker compose -f docker-compose.prod.yml exec -T db \
+      psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+
+# Datasets (pull missing files back; --delete deliberately omitted)
+aws s3 sync s3://$BACKUP_S3_BUCKET/openmv/media/ data/media/
+aws s3 sync s3://$BACKUP_S3_BUCKET/openmv/public/ data/public/
+```
+
+`data/static/` is rebuilt automatically by the next container start —
+don't restore it.
+
 ## Gotchas worth knowing before editing
 
 1. **`DatasetManager.get_queryset` filters out `is_hidden=True` rows from the public site _and_ from the admin list.** `Dataset.objects` is the only manager, so the admin's `DatasetAdmin` queryset is filtered too. To re-edit a hidden dataset, flip `is_hidden` directly in the DB (`./manage.py shell` or a `psql` session) — there is no `all_objects` escape hatch.
@@ -93,7 +178,8 @@ Cloudflare (proxied, orange cloud) ──HTTPS──> Caddy on Hetzner host (TLS
 4. **`DataFile.objects.filter(...)[0]` in `download_dataset`** still uses `[0]` indexing inside a `try/except IndexError`. If you "tidy" it to `.first()`, preserve the same 404 path. (The two `Dataset.objects.filter(...)[0]` siblings have already been migrated to `.first()` + `None` check.)
 5. **`special_message` is rendered with `|safe|escape`** in `all_datasets.html`. The chain is contradictory; `safe` wins. The string is set in the view (not user input), so it's not exploitable today, but don't add user-controlled content to it.
 6. **The `datasetapp` logger is configured by the `LOGGING` dict in `openmv/settings/base.py`** and writes to stdout via a `StreamHandler`. In the production Docker container that means `docker logs` (and any host log shipper) captures everything; locally it streams to the `runserver` terminal. Override the level for ad-hoc debugging by setting `DATASETAPP_LOG_LEVEL=DEBUG` in `.env` or the process env.
-7. **Migration `0002_drop_hit_pii` is what destroys legacy IP / User-Agent / referrer data** in any database that pre-dates v1.3.0 — the columns are dropped, taking every existing value with them. There is no separate retention job because the schema itself no longer holds PII. If you ever restore a pre-v1.3.0 backup, re-run `manage.py migrate` to re-trim it.
+7. **`bin/backup-openmv.sh` deliberately skips `data/static/`.** It mirrors `data/media/` (datasets — the irreplaceable bytes) and `data/public/` (the small Apache-era files), but `collectstatic` regenerates `data/static/` on every container start, so backing it up would just be padding. If you ever add a file under `data/static/` that *isn't* `collectstatic` output, fix the source — don't extend the backup script.
+8. **Migration `0002_drop_hit_pii` is what destroys legacy IP / User-Agent / referrer data** in any database that pre-dates v1.3.0 — the columns are dropped, taking every existing value with them. There is no separate retention job because the schema itself no longer holds PII. If you ever restore a pre-v1.3.0 backup, re-run `manage.py migrate` to re-trim it.
 
 ## Tooling
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,46 @@
 # Releases
 
+## v1.4.0
+
+Off-host backups to AWS S3 — closes #49 and replaces the frozen Linode
+`backup-datasets.sh` cron that had been backing up a stale copy since the
+2026-05-03 Hetzner cutover.
+
+### Highlights
+
+- **`bin/backup-openmv.sh`** (#49): a single host-side bash script that
+  runs nightly under `deploy` from cron. On every invocation it:
+  - dumps Postgres via `docker compose exec -T db pg_dump --clean
+    --if-exists`, gzips the result, and uploads it to
+    `s3://$BACKUP_S3_BUCKET/$BACKUP_S3_PREFIX/db/daily/db_openmv-YYYY-MM-DD.sql.gz`;
+  - promotes the same dump to `db/monthly/db_openmv-YYYY-MM.sql.gz` on the
+    1st of each month and to `db/yearly/db_openmv-YYYY.sql.gz` on Jan 1
+    via a server-side `aws s3 cp` (no second `pg_dump`);
+  - mirrors `data/media/` and `data/public/` to the matching S3 prefixes
+    via `aws s3 sync` *without* `--delete`, so an accidental local rm or a
+    detached bind-mount doesn't propagate to the off-host copy;
+  - prunes `db/daily/` to the 15 most recent objects and `db/monthly/` to
+    the 12 most recent, by S3 `LastModified`. `db/yearly/` is never pruned.
+  Replaces the old `manage.py dumpdata`-based script — `pg_dump` is faster
+  on the ~300k-row `Hit` table and round-trips cleanly across Django
+  versions.
+- **AWS S3, deliberately not Hetzner Object Storage**: the destination
+  sits in a different cloud account from the production VPS so a
+  compromise of one doesn't reach the other.
+- **`data/static/` is intentionally skipped**: `collectstatic` regenerates
+  it on every container start, so it has nothing worth preserving.
+- **`.env.example`**: five new commented-out keys
+  (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`,
+  `BACKUP_S3_BUCKET`, `BACKUP_S3_PREFIX`). The script sources the same
+  `.env` the prod stack uses, so secrets stay in one place.
+- **CLAUDE.md** gains a `## Backups` section (S3 layout, IAM scope, host
+  `awscli` install, cron entry, restore commands) and a new Gotcha (#7)
+  documenting the deliberate `data/static/` skip.
+
+The cron entry itself is **not** auto-installed — it lives outside the
+repo as operational state, documented in CLAUDE.md so the next maintainer
+knows where to put it. No visitor-visible behaviour change.
+
 ## v1.3.0
 
 Privacy fix for the `Hit` table — closes #17 and clears the last

--- a/bin/backup-openmv.sh
+++ b/bin/backup-openmv.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Off-host backup of openmv to AWS S3.
+#
+# Runs on the Hetzner host as the `deploy` user. Three responsibilities:
+#
+#   1. Postgres dump (pg_dump --clean --if-exists, gzipped) of the running
+#      `db` container, uploaded to:
+#        s3://$BACKUP_S3_BUCKET/$BACKUP_S3_PREFIX/db/daily/db_openmv-YYYY-MM-DD.sql.gz
+#      On the 1st of each month the same dump is also copied to
+#        .../db/monthly/db_openmv-YYYY-MM.sql.gz
+#      and on Jan 1 to
+#        .../db/yearly/db_openmv-YYYY.sql.gz
+#
+#   2. `aws s3 sync` of the bind-mounted dataset dirs (data/media/ and
+#      data/public/) to the matching S3 prefixes. No --delete: an accidental
+#      local rm or detached bind-mount must NOT propagate to the off-host
+#      copy. data/static/ is intentionally skipped — collectstatic regenerates
+#      it on every container start, so it has nothing worth preserving.
+#
+#   3. Retention pruning: db/daily/ keeps the 15 most recent objects,
+#      db/monthly/ keeps the 12 most recent. db/yearly/ is never pruned.
+#      Pruning is by S3 LastModified (not by filename parsing).
+#
+# Required env (sourced from the same .env the prod stack uses):
+#   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION
+#   BACKUP_S3_BUCKET                  e.g. openmv-backups
+#   BACKUP_S3_PREFIX                  optional, defaults to "openmv"
+#   POSTGRES_DB, POSTGRES_USER        already present for the prod stack
+#
+# Cron entry (deploy user, intentionally not auto-installed by deploy):
+#   35 21 * * *  /home/deploy/openmv/repo/bin/backup-openmv.sh \
+#       >> /home/deploy/openmv/backups/backup.log 2>&1
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR"
+
+if [[ -f .env ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    source .env
+    set +a
+fi
+
+: "${BACKUP_S3_BUCKET:?BACKUP_S3_BUCKET must be set (in .env or environment)}"
+: "${POSTGRES_DB:?POSTGRES_DB must be set}"
+: "${POSTGRES_USER:?POSTGRES_USER must be set}"
+BACKUP_S3_PREFIX="${BACKUP_S3_PREFIX:-openmv}"
+
+DATE_DAILY="$(date -u +%F)"
+DATE_MONTH="$(date -u +%Y-%m)"
+DATE_YEAR="$(date -u +%Y)"
+DAY_OF_MONTH="$(date -u +%d)"
+MONTH_OF_YEAR="$(date -u +%m)"
+
+S3_BASE="s3://${BACKUP_S3_BUCKET}/${BACKUP_S3_PREFIX}"
+COMPOSE="docker compose -f docker-compose.prod.yml"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+DB_FILE="$TMP_DIR/db_openmv-${DATE_DAILY}.sql.gz"
+
+log() {
+    echo "[backup-openmv] $(date -u +%FT%TZ) $*"
+}
+
+log "starting; bucket=${BACKUP_S3_BUCKET} prefix=${BACKUP_S3_PREFIX}"
+
+# 1. Postgres dump from the running container.
+$COMPOSE exec -T db \
+    pg_dump --no-owner --no-acl --clean --if-exists -Fp \
+    -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+    | gzip -9 > "$DB_FILE"
+log "db dumped: $(du -h "$DB_FILE" | cut -f1)"
+
+# 2. Upload to db/daily/, then promote to monthly/yearly when due.
+aws s3 cp "$DB_FILE" "${S3_BASE}/db/daily/$(basename "$DB_FILE")"
+log "uploaded daily dump"
+
+if [[ "$DAY_OF_MONTH" == "01" ]]; then
+    aws s3 cp \
+        "${S3_BASE}/db/daily/$(basename "$DB_FILE")" \
+        "${S3_BASE}/db/monthly/db_openmv-${DATE_MONTH}.sql.gz"
+    log "promoted to monthly: db_openmv-${DATE_MONTH}.sql.gz"
+fi
+
+if [[ "$MONTH_OF_YEAR" == "01" && "$DAY_OF_MONTH" == "01" ]]; then
+    aws s3 cp \
+        "${S3_BASE}/db/daily/$(basename "$DB_FILE")" \
+        "${S3_BASE}/db/yearly/db_openmv-${DATE_YEAR}.sql.gz"
+    log "promoted to yearly: db_openmv-${DATE_YEAR}.sql.gz"
+fi
+
+# 3. Mirror datasets and small public files. No --delete (see header).
+aws s3 sync data/media "${S3_BASE}/media/"
+log "media synced"
+aws s3 sync data/public "${S3_BASE}/public/"
+log "public synced"
+
+# 4. Prune oldest entries past the retention horizon.
+prune_prefix() {
+    local prefix="$1"
+    local keep="$2"
+    mapfile -t keys < <(
+        aws s3api list-objects-v2 \
+            --bucket "$BACKUP_S3_BUCKET" \
+            --prefix "${BACKUP_S3_PREFIX}/${prefix}" \
+            --query 'reverse(sort_by(Contents,&LastModified))[].Key' \
+            --output text 2>/dev/null \
+            | tr '\t' '\n'
+    )
+    local total=${#keys[@]}
+    if (( total <= keep )); then
+        log "prune ${prefix}: ${total} objects, nothing to remove"
+        return
+    fi
+    local removed=0
+    for key in "${keys[@]:keep}"; do
+        [[ -z "$key" || "$key" == "None" ]] && continue
+        aws s3 rm "s3://${BACKUP_S3_BUCKET}/${key}"
+        removed=$((removed + 1))
+    done
+    log "prune ${prefix}: kept ${keep}, removed ${removed}"
+}
+
+prune_prefix "db/daily/" 15
+prune_prefix "db/monthly/" 12
+# db/yearly/ deliberately never pruned.
+
+log "done"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.3.0"
+version = "1.4.0"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "openmv"
-version = "1.3.0"
+version = "1.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Summary

Closes #49. Replaces the frozen Linode `backup-datasets.sh` cron with an off-host backup that ships to AWS S3 from the Hetzner host.

- **`bin/backup-openmv.sh`** runs nightly under `deploy` from cron and on every invocation:
  - dumps Postgres via `docker compose exec -T db pg_dump --clean --if-exists`, gzips, and uploads to `s3://$BACKUP_S3_BUCKET/$BACKUP_S3_PREFIX/db/daily/db_openmv-YYYY-MM-DD.sql.gz`;
  - promotes the same dump to `db/monthly/` on the 1st of each month and to `db/yearly/` on Jan 1 via server-side `aws s3 cp` (no second `pg_dump`);
  - mirrors `data/media/` and `data/public/` with `aws s3 sync` — **no `--delete`**, so an accidental local rm or detached bind mount won't propagate;
  - prunes `db/daily/` to 15 most recent and `db/monthly/` to 12, by S3 `LastModified`. `db/yearly/` is never pruned.
- **AWS S3, deliberately not Hetzner Object Storage** — the destination sits in a different cloud account from the production VPS so a compromise of one doesn't reach the other.
- **`data/static/` is intentionally skipped** — `collectstatic` regenerates it on every container start.
- `.env.example` gains five commented-out keys (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `BACKUP_S3_BUCKET`, `BACKUP_S3_PREFIX`). Script sources the same `.env` the prod stack uses.
- `CLAUDE.md` gains a `## Backups` section (S3 layout, IAM scope, host `awscli` install, cron entry, restore commands) and a Gotcha documenting the deliberate `data/static/` skip.
- `pyproject.toml` + `RELEASES.md` bump to **v1.4.0** (MINOR — additive infra feature, no visitor-visible behaviour change).

The cron entry itself is **not** auto-installed; it's documented in CLAUDE.md as operational state the next maintainer needs to put in place once.

## S3 layout

```
s3://$BACKUP_S3_BUCKET/$BACKUP_S3_PREFIX/
├── db/
│   ├── daily/    db_openmv-YYYY-MM-DD.sql.gz   (≤15)
│   ├── monthly/  db_openmv-YYYY-MM.sql.gz      (≤12)
│   └── yearly/   db_openmv-YYYY.sql.gz         (∞)
├── media/        mirror of data/media/
└── public/       mirror of data/public/
```

## Test plan

- [x] `bash -n bin/backup-openmv.sh` — passes
- [x] `uv run pre-commit run --all-files` — passes
- [x] `SECRET_KEY=… uv run pytest` — all 9 tests pass (no Python touched)
- [ ] Manual run on Hetzner: `ssh deploy@hetzner && cd /home/deploy/openmv/repo && ./bin/backup-openmv.sh`. Verify a `db_openmv-<today>.sql.gz` lands under `db/daily/` and `data/media/` mirrors under `media/` (`aws s3 ls` confirms).
- [ ] Restore drill: pull the day's dump back, restore into a throwaway Postgres container, run `python manage.py check` against it.
- [ ] Install the cron entry on Hetzner as `deploy` (one-shot, documented in CLAUDE.md).

## Out of scope

- GPG-encrypting dumps before upload (issue's third open question — SSE-S3 + scoped IAM principal is the chosen tradeoff).
- Bucket creation, IAM policy, or S3 versioning — one-time AWS console setup, documented as recommendations in CLAUDE.md.
- Automated restore tests in CI.

https://claude.ai/code/session_011rzZA9o1boR5wibGDjWaWM

---
_Generated by [Claude Code](https://claude.ai/code/session_011rzZA9o1boR5wibGDjWaWM)_