### PR TITLE
Add sortable columns to homepage table (#81)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,29 @@
 # Releases
 
+## v1.6.0
+
+Sortable columns on the homepage / tag-filter table (issue #81). Click any
+column header (Name, Description, Rows, Columns, Tags) to sort ascending;
+click again to flip to descending. The active column shows an up/down
+arrow; the others are unsorted.
+
+- **`datasetapp/templates/datasetapp/all_datasets.html`**: header `<td>`s
+  promoted to `<th scope="col">` wrapping a `<button class="col-sort">`,
+  body cells annotated with `data-sort-key` + `data-sort-value` (lower-cased
+  text for textual columns, raw integers for `Rows` / `Columns`, joined tag
+  names for the tag column). Inline script reorders `<tr>` elements in
+  place — no network calls, no re-render of the row body, and tag links
+  stay clickable. Default order on load is the server-side `slug`
+  ordering, marked `aria-sort="ascending"` on the Name column.
+- **`datasetapp/templates/datasetapp/base.html`**: CSS for the new
+  `.col-sort` button (full-width hit target, hover affordance) and the
+  up/down/unsorted arrow indicator driven by `aria-sort` (mask-image SVG,
+  inherits `currentColor` so it tracks light / dark theme).
+
+Behaviour-preserving for visitors with JavaScript disabled: the table
+still renders in the existing slug order and column header text remains
+visible — only the click-to-sort affordance is lost.
+
 ## v1.5.1
 
 Documentation-only follow-up to v1.4.0's S3 backup work. No code changes.

--- a/datasetapp/templates/datasetapp/all_datasets.html
+++ b/datasetapp/templates/datasetapp/all_datasets.html
@@ -21,7 +21,7 @@ Datasets{% endif %}{% endblock %}
 {% endif %}
 
 <div class="dataset-results">
-    <table class="dataset-table">
+    <table class="dataset-table" id="dataset-table">
         <colgroup>
             <col class="col-name">
             <col class="col-desc">
@@ -31,22 +31,22 @@ Datasets{% endif %}{% endblock %}
         </colgroup>
         <thead>
             <tr>
-                <td>Name</td>
-                <td>Description</td>
-                <td>Rows</td>
-                <td>Columns</td>
-                <td>Tags</td>
+                <th scope="col" aria-sort="ascending"><button type="button" class="col-sort" data-sort-key="name" data-sort-type="text">Name</button></th>
+                <th scope="col" aria-sort="none"><button type="button" class="col-sort" data-sort-key="desc" data-sort-type="text">Description</button></th>
+                <th scope="col" aria-sort="none"><button type="button" class="col-sort" data-sort-key="rows" data-sort-type="number">Rows</button></th>
+                <th scope="col" aria-sort="none"><button type="button" class="col-sort" data-sort-key="cols" data-sort-type="number">Columns</button></th>
+                <th scope="col" aria-sort="none"><button type="button" class="col-sort" data-sort-key="tags" data-sort-type="text">Tags</button></th>
             </tr>
         </thead>
         <tbody>
         {% for dataset in dataset_list %}
         {% spaceless %}
         <tr class="dataset-row">
-            <td><a href="{% url 'datasetapp:dataset-about-a-dataset' dataset.slug %}">{{ dataset.name }}</a></td>
-            <td>{{dataset.description|striptags}}</td>
-            <td class="dataset-rows">{{dataset.rows}}</td>
-            <td class="dataset-cols">{{dataset.cols}}</td>
-            <td>
+            <td data-sort-key="name" data-sort-value="{{ dataset.name|lower }}"><a href="{% url 'datasetapp:dataset-about-a-dataset' dataset.slug %}">{{ dataset.name }}</a></td>
+            <td data-sort-key="desc" data-sort-value="{{ dataset.description|striptags|lower }}">{{dataset.description|striptags}}</td>
+            <td class="dataset-rows" data-sort-key="rows" data-sort-value="{{ dataset.rows }}">{{dataset.rows}}</td>
+            <td class="dataset-cols" data-sort-key="cols" data-sort-value="{{ dataset.cols }}">{{dataset.cols}}</td>
+            <td data-sort-key="tags" data-sort-value="{% for tag in dataset.tags.all %}{{ tag|lower }} {% endfor %}">
                 <div class="tag-list">
                 {% for tag in dataset.tags.all %}
                 <a href="{% url 'datasetapp:dataset-by-tag' tag %}" class="dataset-tag" title="{{tag.description}}">{{tag}}</a>
@@ -59,4 +59,51 @@ Datasets{% endif %}{% endblock %}
         </tbody>
     </table>
 </div>
+
+<script>
+(function () {
+    var table = document.getElementById('dataset-table');
+    if (!table) return;
+    var thead = table.tHead;
+    var tbody = table.tBodies[0];
+    if (!thead || !tbody) return;
+
+    var headerCells = thead.rows[0].cells;
+
+    function sortBy(key, type, dir) {
+        var rows = Array.prototype.slice.call(tbody.rows);
+        var mult = dir === 'descending' ? -1 : 1;
+        rows.sort(function (a, b) {
+            var av = a.querySelector('[data-sort-key="' + key + '"]').getAttribute('data-sort-value') || '';
+            var bv = b.querySelector('[data-sort-key="' + key + '"]').getAttribute('data-sort-value') || '';
+            if (type === 'number') {
+                var an = parseFloat(av);
+                var bn = parseFloat(bv);
+                if (isNaN(an) && isNaN(bn)) return 0;
+                if (isNaN(an)) return 1;
+                if (isNaN(bn)) return -1;
+                return (an - bn) * mult;
+            }
+            return av.localeCompare(bv) * mult;
+        });
+        var frag = document.createDocumentFragment();
+        rows.forEach(function (r) { frag.appendChild(r); });
+        tbody.appendChild(frag);
+    }
+
+    Array.prototype.forEach.call(headerCells, function (th) {
+        var btn = th.querySelector('.col-sort');
+        if (!btn) return;
+        btn.addEventListener('click', function () {
+            var current = th.getAttribute('aria-sort') || 'none';
+            var next = current === 'ascending' ? 'descending' : 'ascending';
+            Array.prototype.forEach.call(headerCells, function (other) {
+                other.setAttribute('aria-sort', 'none');
+            });
+            th.setAttribute('aria-sort', next);
+            sortBy(btn.dataset.sortKey, btn.dataset.sortType, next);
+        });
+    });
+})();
+</script>
 {% endblock %}

--- a/datasetapp/templates/datasetapp/base.html
+++ b/datasetapp/templates/datasetapp/base.html
@@ -289,14 +289,47 @@ p  { margin: 0 0 var(--sp-3) 0; }
     box-shadow: var(--shadow-sm);
 }
 .dataset-table thead { background: var(--color-surface-2); }
-.dataset-table thead td {
+.dataset-table thead td,
+.dataset-table thead th {
     font-family: var(--font-sans); font-weight: 600;
     font-size: var(--fs-xs);
     text-transform: uppercase; letter-spacing: 0.08em;
     color: var(--color-text-subtle);
-    padding: var(--sp-3);
+    padding: 0;
     text-align: left;
     border-bottom: 1px solid var(--color-border);
+}
+.dataset-table thead .col-sort {
+    width: 100%;
+    display: inline-flex; align-items: center; gap: var(--sp-2);
+    padding: var(--sp-3);
+    font: inherit; color: inherit;
+    text-transform: inherit; letter-spacing: inherit;
+    text-align: left;
+    background: none; border: 0;
+    cursor: pointer;
+    transition: color var(--transition), background var(--transition);
+}
+.dataset-table thead .col-sort:hover { color: var(--color-text); background: var(--color-surface); }
+.dataset-table thead .col-sort::after {
+    content: "";
+    width: 8px; height: 12px; flex: 0 0 8px;
+    background: currentColor;
+    opacity: 0.35;
+    -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 12'><path d='M4 0 L8 4 L0 4 Z M4 12 L0 8 L8 8 Z' fill='black'/></svg>") center/contain no-repeat;
+            mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 12'><path d='M4 0 L8 4 L0 4 Z M4 12 L0 8 L8 8 Z' fill='black'/></svg>") center/contain no-repeat;
+}
+.dataset-table thead [aria-sort="ascending"] .col-sort,
+.dataset-table thead [aria-sort="descending"] .col-sort { color: var(--color-text); }
+.dataset-table thead [aria-sort="ascending"] .col-sort::after {
+    opacity: 1;
+    -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 12'><path d='M4 0 L8 4 L0 4 Z' fill='black'/></svg>") center/contain no-repeat;
+            mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 12'><path d='M4 0 L8 4 L0 4 Z' fill='black'/></svg>") center/contain no-repeat;
+}
+.dataset-table thead [aria-sort="descending"] .col-sort::after {
+    opacity: 1;
+    -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 12'><path d='M4 12 L0 8 L8 8 Z' fill='black'/></svg>") center/contain no-repeat;
+            mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 12'><path d='M4 12 L0 8 L8 8 Z' fill='black'/></svg>") center/contain no-repeat;
 }
 .dataset-table tbody td {
     padding: var(--sp-3);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.5.1"
+version = "1.6.0"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "openmv"
-version = "1.5.1"
+version = "1.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "bleach" },


### PR DESCRIPTION
Closes #81.

## Summary

Click any column header on the homepage / tag-filter table (Name, Description, Rows, Columns, Tags) to sort ascending; click again to flip to descending. The active column shows an up/down arrow; the others render an unsorted (double-arrow) indicator.

- **`datasetapp/templates/datasetapp/all_datasets.html`**: header `<td>` cells promoted to `<th scope="col">` wrapping a `<button class="col-sort">`. Body cells annotated with `data-sort-key` + `data-sort-value` (lower-cased text for textual columns, raw integers for `Rows`/`Columns`, joined tag names for the tag column). Inline script reorders `<tr>` elements in place — no network calls, no re-render of the row body, and tag links / anchor cells stay clickable. Default load order is the server-side `slug` ordering, marked `aria-sort="ascending"` on the Name column.
- **`datasetapp/templates/datasetapp/base.html`**: CSS for the new `.col-sort` button (full-width hit target, hover affordance) and an arrow indicator driven by `aria-sort`. Indicator uses `currentColor` so it tracks light/dark theme.

Behaviour-preserving for visitors with JavaScript disabled: the table still renders in the existing slug order with column headings visible — only the click-to-sort affordance is lost.

## Version

v1.5.1 → v1.6.0 (MINOR — additive feature). `RELEASES.md` updated with a matching `## v1.6.0` section per the project's release-pipeline contract.

## Test plan

- [x] `pytest` — all 37 existing smoke tests pass (no view/URL changes; only template + inline JS).
- [x] `pre-commit run --all-files` — clean.
- [ ] Manual: `make debug`, click each header on `/` and `/tag/<slug>` — confirm rows reorder, arrow indicators flip, tag links remain clickable, mobile card view (where `<thead>` is hidden by CSS) is unaffected.
- [ ] Manual: dark-mode + light-mode visual check of the arrow indicator.

https://claude.ai/code/session_01PmmHLJq74rYHx2huX9bDyU

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmmHLJq74rYHx2huX9bDyU)_