### PR TITLE
Add /healthz view and Dockerfile HEALTHCHECK (v1.5.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,18 @@ matching `RELEASES.md` section land on `master`. The workflow refuses to run
 if the `## v<version>` heading is missing — that's the safety net. **Do not**
 create tags manually.
 
+## After opening a PR
+
+Once a PR is posted, watch it. If `master` advances and the PR develops merge
+conflicts, resolve them on the PR branch and push the merge commit — don't
+leave the PR sitting in a conflicted state waiting for the human reviewer to
+rebase. When the conflict is in `pyproject.toml` / `RELEASES.md` because
+another PR landed a version bump, renumber your section to the next
+appropriate level on top of the new `master` version (re-apply the PATCH /
+MINOR / MAJOR heuristic above against the new base) and update any
+`docs/SECURITY.md` "Fixed in vX.Y.Z" cross-references to match. Re-run
+`pytest` and `pre-commit` after the merge before pushing.
+
 ## Outstanding work
 
 The GitHub issue tracker is the single source of truth for outstanding work: <https://github.com/kgdunn/Django-dataset-download-app/issues>. Don't duplicate the list here — it goes stale.

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN uv sync --frozen --no-install-project --no-dev
 FROM python:3.11-slim AS runtime
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libpq5 \
+    && apt-get install -y --no-install-recommends libpq5 curl \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --create-home --uid 1000 app
 
@@ -42,5 +42,12 @@ ENV PATH="/app/.venv/bin:$PATH" \
 USER app
 
 EXPOSE 8000
+
+# Liveness probe: hits the @never_cache /healthz view in datasetapp/urls.py.
+# `-f` so a 5xx still fails the check (curl exits non-zero on HTTP errors only
+# when -f is set). 30s × 3 retries ⇒ container flips to (unhealthy) within
+# ~90s of gunicorn going dark.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8000/healthz || exit 1
 
 CMD ["gunicorn", "openmv.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,28 @@
 # Releases
 
+## v1.5.2
+
+Operational follow-up to v1.5.0's audit. Adds a Docker liveness probe so a
+half-broken container (gunicorn workers blocked on a slow query, OOM-killed,
+etc.) flips to `(unhealthy)` and `restart: unless-stopped` can recycle it.
+Closes Issue I in `docs/SECURITY.md`.
+
+- **`datasetapp/views.py`**: new `healthz(request)` view, decorated with
+  `@never_cache`, returning `HttpResponse("ok\n", content_type="text/plain")`.
+  No DB, no template, no auth — pure liveness signal.
+- **`datasetapp/urls.py`**: wired at `/healthz` (reverse name
+  `datasetapp:healthz`). Mounted at the top of the patterns; outside `/admin/`
+  so any future Caddy or Cloudflare admin rate-limit doesn't touch it.
+- **`Dockerfile`**: runtime stage installs `curl` (alongside `libpq5`) and
+  adds `HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3
+  CMD curl -fsS http://127.0.0.1:8000/healthz`. The `-f` flag is required so
+  a 5xx still fails the check.
+- **`datasetapp/tests/test_views.py`**: three smoke tests pin the contract —
+  200 + `ok\n` + `text/plain`, `Cache-Control: no-cache, no-store, max-age=0`
+  (proves `@never_cache` is applied), and no `Hit` row written (proves the
+  view doesn't accidentally exercise the download codepath).
+- **`docs/SECURITY.md`**: Issue I marked **Fixed in v1.5.2**.
+
 ## v1.5.1
 
 Documentation-only follow-up to v1.4.0's S3 backup work. No code changes.

--- a/datasetapp/tests/test_views.py
+++ b/datasetapp/tests/test_views.py
@@ -137,6 +137,29 @@ def test_about_omits_preview_when_only_non_csv_files(client, db):
     assert "dataset-preview" not in response.content.decode()
 
 
+def test_healthz_returns_200_plain_ok(client, db):
+    response = client.get(reverse("datasetapp:healthz"))
+    assert response.status_code == 200
+    assert response.content == b"ok\n"
+    assert response.headers["Content-Type"].startswith("text/plain")
+
+
+def test_healthz_disables_caching(client, db):
+    # @never_cache must be applied so Caddy/Cloudflare can't serve a stale
+    # "ok" past the point of failure.
+    response = client.get(reverse("datasetapp:healthz"))
+    cache_control = response.headers.get("Cache-Control", "")
+    assert "no-cache" in cache_control
+    assert "no-store" in cache_control
+    assert "max-age=0" in cache_control
+
+
+def test_healthz_does_not_record_a_hit(client, db):
+    before = Hit.objects.count()
+    client.get(reverse("datasetapp:healthz"))
+    assert Hit.objects.count() == before
+
+
 def test_about_includes_download_series_for_sparkline(client, dataset, csv_file):
     Hit.objects.create(dataset_hit=csv_file)
     response = client.get(

--- a/datasetapp/urls.py
+++ b/datasetapp/urls.py
@@ -4,6 +4,9 @@ from . import views
 
 app_name = "datasetapp"
 urlpatterns = [
+    # Liveness probe for Docker HEALTHCHECK. Kept outside /admin/ so
+    # Caddy/Cloudflare rate-limits don't apply to it.
+    path("healthz", views.healthz, name="healthz"),
     # Home page
     path("", views.display_all, name="dataset-home-page"),
     # Get all details for a dataset

--- a/datasetapp/views.py
+++ b/datasetapp/views.py
@@ -24,6 +24,7 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import reverse as django_reverse
 from django.utils import timezone
+from django.views.decorators.cache import never_cache
 
 # Model imports
 from .models import DataFile, Dataset, Hit, Tag
@@ -36,6 +37,15 @@ log_file = logging.getLogger("datasetapp")
 # ValueError on a missing/extra dot, which surfaced as a 500 and noise in the
 # logs.
 _DOWNLOAD_FILENAME_RE = re.compile(r"^[a-z0-9-]+\.[a-z]{3}$")
+
+
+@never_cache
+def healthz(request):
+    # Liveness probe for Docker HEALTHCHECK and any upstream
+    # depends_on: condition: service_healthy. Must not touch the DB,
+    # render a template, or be cacheable — Caddy/Cloudflare caching a
+    # stale "ok" past a failure would defeat the check.
+    return HttpResponse("ok\n", content_type="text/plain")
 
 
 def display_by_tag(request, tag):

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -182,6 +182,7 @@ attached to the audit, not to a transient PR description.
 - **Severity:** Low.
 - **Why:** Caddy currently has no signal whether gunicorn is unhealthy mid-request beyond its own connect-failure detection.
 - **Proposed fix:** Add a lightweight `/healthz` view (returns `200 OK` with cache disabled and never touches the DB) and a `HEALTHCHECK CMD curl -fsS http://127.0.0.1:8000/healthz` in the runtime stage.
+- **Status:** **Fixed in v1.5.2** — `datasetapp.views.healthz` (decorated with `@never_cache`, no DB / template / auth) wired at `/healthz`; `Dockerfile` runtime stage installs `curl` and runs `HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 CMD curl -fsS http://127.0.0.1:8000/healthz`. Container flips to `(unhealthy)` within ~90 s of gunicorn going dark.
 
 ### Issue J — Pin GitHub Actions to full commit SHAs
 - **Severity:** Low (supply chain).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.5.1"
+version = "1.5.2"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "openmv"
-version = "1.5.1"
+version = "1.5.2"
 source = { virtual = "." }
 dependencies = [
     { name = "bleach" },


### PR DESCRIPTION
Closes #78. Resolves Issue I in `docs/SECURITY.md`.

## Summary

- New `healthz` view in `datasetapp/views.py` — `@never_cache`, no DB / template / auth, returns `HttpResponse("ok\n", content_type="text/plain")`.
- Wired at `/healthz` in `datasetapp/urls.py` (mounted outside `/admin/` so any future Caddy or Cloudflare admin rate-limit doesn't touch it).
- `Dockerfile` runtime stage installs `curl` alongside `libpq5` and adds `HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 CMD curl -fsS http://127.0.0.1:8000/healthz`. The `-f` flag is essential so a 5xx still fails the check.
- Three new smoke tests in `datasetapp/tests/test_views.py` pin the contract: 200 + `ok\n` + `text/plain`; `Cache-Control: no-cache, no-store, max-age=0` (proves `@never_cache` is applied); and no `Hit` row written.
- `docs/SECURITY.md` Issue I marked **Fixed in v1.5.2**.
- `pyproject.toml` + `RELEASES.md` bumped 1.5.1 → 1.5.2 (PATCH — additive, no behaviour change).

## Why

Caddy currently detects connect-failures but cannot tell whether gunicorn is up-but-stuck (workers blocked on a slow DB query, OOM-killed, etc.). `restart: unless-stopped` won't recycle a half-broken container. The `HEALTHCHECK` lets Docker mark the container `(unhealthy)` within ~90s of gunicorn going dark, and lets future compose dependents use `depends_on: condition: service_healthy`.

## Test plan

- [x] `uv run pytest` — 40 passed (37 prior + 3 new healthz tests).
- [x] `uv run pre-commit run --all-files` — all hooks pass (mypy, isort, black, flake8, blacken-docs, etc.).
- [ ] After deploy: `curl -i http://127.0.0.1:8001/healthz` on the Hetzner host returns 200 + `ok\n`.
- [ ] After deploy: `docker ps --filter name=openmv-app --format "{{.Status}}"` shows `(healthy)` ~25s after start.
- [ ] After deploy (smoke): `docker compose -f docker-compose.prod.yml kill -s KILL web` (or signal individual workers) → `docker ps` flips to `(unhealthy)` within ~90s.

https://claude.ai/code/session_01GG3RfAzd85TmxacVg5GuTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GG3RfAzd85TmxacVg5GuTZ)_