### PR TITLE
v1.7.0: add sortable Downloads column to homepage (issue #92)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ The Django site behind <https://openmv.net> — a dataset catalogue that lists, 
 - **Models** (`datasetapp/models.py`): `Tag`, `Dataset`, `DataFile`, `Hit`.
   - `Dataset` ↔ `Tag` is many-to-many.
   - `Dataset` ↔ `DataFile` is one-to-many (a dataset can have CSV + XLS + XML + MAT siblings).
-  - `Hit` records one download. Since v1.3.0 (#17) the table holds only `(dataset_hit, date_and_time)` — no IP, User-Agent, or referrer is captured. Two columns power both visible features: the per-dataset count on the detail page and the 365-day sparkline (`_download_series` in `datasetapp/views.py` groups rows by `TruncDate("date_and_time")`). Rows are kept indefinitely; the per-row history is fine to retain because no PII is stored.
+  - `Hit` records one download. Since v1.3.0 (#17) the table holds only `(dataset_hit, date_and_time)` — no IP, User-Agent, or referrer is captured. Two columns power three visible features: the per-dataset count on the detail page, the sortable Downloads column on the homepage / tag-filter list (v1.7.0, via a `Count("datafile__hit", distinct=True)` annotation in `_annotate_with_downloads`; desktop-only — the mobile card layout hides it), and the 365-day sparkline on the detail page (`_download_series` in `datasetapp/views.py` groups rows by `TruncDate("date_and_time")`). Rows are kept indefinitely; the per-row history is fine to retain because no PII is stored.
 - **Views** (`datasetapp/views.py`):
   - `display_all` — `/` — homepage table.
   - `display_by_tag` — `/tag/<slug>` — filter by tag.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,41 @@
 # Releases
 
+## v1.7.0
+
+Feature for issue #92 — the homepage table (and the per-tag filter view at
+`/tag/<slug>`) now includes a sortable **Downloads** column showing the
+all-time number of downloads per dataset. The count is the same value the
+detail page already exposes (one row per `Hit`), so visitors can sort the
+catalogue by popularity without leaving the index. Scoped to the desktop
+layout per the issue; the mobile card view hides the column to avoid
+crowding cards that already condense Rows/Cols inline.
+
+- **`datasetapp/views.py`**: new `_annotate_with_downloads(queryset)`
+  helper that adds a `num_downloads=Count("datafile__hit", distinct=True)`
+  annotation. `display_all` and `display_by_tag` route their queryset
+  through it before handing the list to the template. `distinct=True` is
+  required because `display_by_tag` filters via the `tags` M2M, and a
+  multi-tag match would otherwise multiply the Hit count by the number of
+  matching tags.
+- **`datasetapp/templates/datasetapp/all_datasets.html`**: new `<col
+  class="col-downloads">`, new sortable `<th>` with
+  `data-sort-key="downloads" data-sort-type="number"`, new `<td
+  class="dataset-downloads">` rendering `dataset.num_downloads|default:0`
+  with the same `data-sort-value` shape the existing JS sorter expects.
+- **`datasetapp/templates/datasetapp/base.html`**: column widths
+  rebalanced to fit the new column (Name 17%, Rows 8%, Cols 9%, Downloads
+  11%, Tags 24%); `.dataset-downloads` cells inherit the right-aligned
+  monospaced styling already used by `.dataset-rows` / `.dataset-cols`.
+  Inside the `@media (max-width: 767px)` block,
+  `.dataset-table tbody td.dataset-downloads` is set to `display: none`
+  so the mobile card layout is unchanged.
+- **`datasetapp/tests/test_views.py`**: new
+  `test_home_renders_downloads_column_with_per_dataset_counts` asserts
+  the column markers and the per-dataset count surface in the homepage
+  HTML; new `test_tag_view_does_not_double_count_downloads` locks the
+  `distinct=True` requirement against regressions where the M2M tag join
+  silently multiplies the Hit count.
+
 ## v1.6.4
 
 Bugfix for issue #86 — `pandas.read_csv("https://openmv.net/file/<slug>.csv")`

--- a/datasetapp/templates/datasetapp/all_datasets.html
+++ b/datasetapp/templates/datasetapp/all_datasets.html
@@ -27,6 +27,7 @@ Datasets{% endif %}{% endblock %}
             <col class="col-desc">
             <col class="col-rows">
             <col class="col-cols">
+            <col class="col-downloads">
             <col class="col-tags">
         </colgroup>
         <thead>
@@ -35,6 +36,7 @@ Datasets{% endif %}{% endblock %}
                 <th scope="col" aria-sort="none"><button type="button" class="col-sort" data-sort-key="desc" data-sort-type="text">Description</button></th>
                 <th scope="col" aria-sort="none"><button type="button" class="col-sort" data-sort-key="rows" data-sort-type="number">Rows</button></th>
                 <th scope="col" aria-sort="none"><button type="button" class="col-sort" data-sort-key="cols" data-sort-type="number">Columns</button></th>
+                <th scope="col" aria-sort="none"><button type="button" class="col-sort" data-sort-key="downloads" data-sort-type="number">Downloads</button></th>
                 <th scope="col" aria-sort="none"><button type="button" class="col-sort" data-sort-key="tags" data-sort-type="text">Tags</button></th>
             </tr>
         </thead>
@@ -46,6 +48,7 @@ Datasets{% endif %}{% endblock %}
             <td data-sort-key="desc" data-sort-value="{{ dataset.description|striptags|lower }}">{{dataset.description|striptags}}</td>
             <td class="dataset-rows" data-sort-key="rows" data-sort-value="{{ dataset.rows }}">{{dataset.rows}}</td>
             <td class="dataset-cols" data-sort-key="cols" data-sort-value="{{ dataset.cols }}">{{dataset.cols}}</td>
+            <td class="dataset-downloads" data-sort-key="downloads" data-sort-value="{{ dataset.num_downloads|default:0 }}">{{ dataset.num_downloads|default:0 }}</td>
             <td data-sort-key="tags" data-sort-value="{% for tag in dataset.tags.all %}{{ tag|lower }} {% endfor %}">
                 <div class="tag-list">
                 {% for tag in dataset.tags.all %}

--- a/datasetapp/templates/datasetapp/base.html
+++ b/datasetapp/templates/datasetapp/base.html
@@ -340,12 +340,14 @@ p  { margin: 0 0 var(--sp-3) 0; }
 .dataset-table tbody tr:last-child td { border-bottom: 0; }
 .dataset-table tbody tr:hover { background: var(--color-surface-2); }
 .dataset-table tbody td:first-child a { font-weight: 500; }
-.dataset-table .col-name { width: 19%; }
-.dataset-table .col-rows { width: 9%; }
-.dataset-table .col-cols { width: 10%; }
-.dataset-table .col-tags { width: 26%; }
+.dataset-table .col-name { width: 17%; }
+.dataset-table .col-rows { width: 8%; }
+.dataset-table .col-cols { width: 9%; }
+.dataset-table .col-downloads { width: 11%; }
+.dataset-table .col-tags { width: 24%; }
 .dataset-table tbody td.dataset-rows,
-.dataset-table tbody td.dataset-cols {
+.dataset-table tbody td.dataset-cols,
+.dataset-table tbody td.dataset-downloads {
     font-family: var(--font-mono); font-variant-numeric: tabular-nums;
     text-align: right; color: var(--color-text-muted);
 }
@@ -382,6 +384,7 @@ p  { margin: 0 0 var(--sp-3) 0; }
     .dataset-table tbody td.dataset-cols {
         display: inline-block; margin-right: var(--sp-4); text-align: left;
     }
+    .dataset-table tbody td.dataset-downloads { display: none; }
 }
 
 /* Tag-filter intro card */

--- a/datasetapp/tests/test_views.py
+++ b/datasetapp/tests/test_views.py
@@ -58,6 +58,47 @@ def test_home_returns_200(client, dataset):
     assert response.status_code == 200
 
 
+def test_home_renders_downloads_column_with_per_dataset_counts(
+    client, dataset, csv_file
+):
+    Hit.objects.create(dataset_hit=csv_file)
+    Hit.objects.create(dataset_hit=csv_file)
+    response = client.get(reverse("datasetapp:dataset-home-page"))
+    body = response.content.decode()
+    assert response.status_code == 200
+    assert 'data-sort-key="downloads"' in body
+    assert 'class="dataset-downloads"' in body
+    assert 'data-sort-value="2"' in body
+
+
+def test_tag_view_does_not_double_count_downloads(client, db):
+    ds = Dataset.objects.create(
+        name="Multi",
+        slug="multi",
+        description="d",
+        author_name="a",
+        usage_restrictions="None",
+        data_source="s",
+    )
+    df = DataFile.objects.create(
+        file_type="CSV", link_to_file="datasets/multi.csv", dataset=ds
+    )
+    # Two tags both starting with "chem" would otherwise multiply the Hit
+    # count via the M2M join in display_by_tag.
+    for tag_name in ("chem", "chemistry"):
+        t = Tag.objects.create(name=tag_name, description="x")
+        ds.tags.add(t)
+    Hit.objects.create(dataset_hit=df)
+    Hit.objects.create(dataset_hit=df)
+    Hit.objects.create(dataset_hit=df)
+
+    response = client.get(reverse("datasetapp:dataset-by-tag", args=["chem"]))
+    body = response.content.decode()
+    assert response.status_code == 200
+    assert 'data-sort-value="3"' in body
+    assert 'data-sort-value="6"' not in body
+
+
 def test_about_known_slug_returns_200(client, dataset, csv_file):
     response = client.get(
         reverse("datasetapp:dataset-about-a-dataset", args=[dataset.slug])

--- a/datasetapp/views.py
+++ b/datasetapp/views.py
@@ -48,12 +48,26 @@ def healthz(request):
     return HttpResponse("ok\n", content_type="text/plain")
 
 
+def _annotate_with_downloads(queryset):
+    """Attach a ``num_downloads`` aggregate to each ``Dataset`` row.
+
+    ``distinct=True`` is required because callers may have already joined
+    the M2M ``tags`` relation (``display_by_tag``); without it the tag
+    join would multiply the Hit count by the number of matching tags.
+    """
+    return queryset.annotate(
+        num_downloads=Count("datafile__hit", distinct=True),
+    )
+
+
 def display_by_tag(request, tag):
     """
     Shows only the datasets with the given tag
     """
     log_file.debug("Tag view for tag=%s" % tag)
-    dataset_list = Dataset.objects.filter(tags__name__startswith=tag)
+    dataset_list = _annotate_with_downloads(
+        Dataset.objects.filter(tags__name__startswith=tag)
+    )
 
     context = {
         "dataset_list": dataset_list,
@@ -69,7 +83,7 @@ def display_all(request):
     """
     Displays all datasets in a table form, with brief summaries.
     """
-    dataset_list = Dataset.objects.order_by("slug")[:]
+    dataset_list = _annotate_with_downloads(Dataset.objects.order_by("slug"))[:]
     context = {"dataset_list": dataset_list}
     return TemplateResponse(request, "datasetapp/all_datasets.html", context)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.6.4"
+version = "1.7.0"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "openmv"
-version = "1.6.4"
+version = "1.7.0"
 source = { virtual = "." }
 dependencies = [
     { name = "bleach" },


### PR DESCRIPTION
## Summary

Closes #92.

- Adds a sortable **Downloads** column to the homepage table (`/`) and the tag-filter list (`/tag/<slug>`), showing the all-time number of downloads per dataset (one per `Hit` row).
- Scoped to the **desktop** layout per the issue: the existing mobile card layout (`@media (max-width: 767px)`) hides the new column so cards stay compact (Rows/Cols are already condensed inline there).
- Backend implementation is a single annotation on the `Dataset` queryset: `Count("datafile__hit", distinct=True)`. `distinct=True` is required because `display_by_tag` filters via the `tags` M2M — without it, a dataset with multiple matching tags would have its Hit count multiplied by the number of matching tags.

## Files changed

- `datasetapp/views.py` — new `_annotate_with_downloads(queryset)` helper; `display_all` and `display_by_tag` route through it.
- `datasetapp/templates/datasetapp/all_datasets.html` — new `<col class="col-downloads">`, sortable header (`data-sort-key="downloads" data-sort-type="number"`), and `<td class="dataset-downloads">` cell rendering `dataset.num_downloads|default:0` with the matching `data-sort-value`.
- `datasetapp/templates/datasetapp/base.html` — column widths rebalanced (Name 17%, Rows 8%, Cols 9%, Downloads 11%, Tags 24%); `.dataset-downloads` inherits the right-aligned monospaced styling already shared by `.dataset-rows` / `.dataset-cols`; `display: none` inside the mobile breakpoint.
- `datasetapp/tests/test_views.py` — two new tests: `test_home_renders_downloads_column_with_per_dataset_counts` (asserts the column markers and per-dataset count surface in the homepage HTML) and `test_tag_view_does_not_double_count_downloads` (locks the `distinct=True` requirement so the M2M tag join can't silently multiply the Hit count).
- `RELEASES.md`, `pyproject.toml`, `uv.lock` — version bump to **1.7.0** (additive feature → MINOR per the policy in CLAUDE.md).
- `CLAUDE.md` — Models section updated: `Hit` now powers three visible features instead of two.

## Test plan

- [x] `uv run pytest` — 45 passed (was 43)
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [ ] Visual check on `test.openmv.net` after deploy: column renders on desktop, sorts ascending/descending on click, mobile card view unchanged.

https://claude.ai/code/session_01QRz1PrFYWCQD7YZUc2jQns

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRz1PrFYWCQD7YZUc2jQns)_