### PR TITLE
v1.7.1: document Cloudflare config that closes issue #95

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,34 @@
 # Releases
 
+## v1.7.1
+
+Docs-only patch for issue #95 — the v1.6.4 origin-side fix for
+`HTTPError: HTTP Error 403: Forbidden` on
+`pandas.read_csv("https://openmv.net/file/<slug>.csv")` was necessary
+but not sufficient: Cloudflare's Bot Fight Mode (BFM) continued to 403
+the `Python-urllib/*` User-Agent from AWS / GitHub Actions ASNs even
+after `/file/*` stopped redirecting through `/media/*`. The actual cure
+turned out to be two pure-Cloudflare configuration changes (no code
+change, no client-side workaround needed). This release records what is
+now configured on the production zone.
+
+- **`docs/SECURITY.md`**: rewrote the "Bot Fight Mode and dataset
+  downloads" subsection to document the production configuration:
+  (1) BFM is **off** site-wide on the Free plan because BFM cannot be
+  skipped per-path by WAF Custom Rules or Configuration Rules on Free
+  — the "Skip" action only exempts **Super** BFM (Pro+); (2) a
+  Configuration Rule on `URI Path starts_with /file/` sets Browser
+  Integrity Check to Off. Added the `curl -A 'Python-urllib/3.12'`
+  verification command, the trade-offs of turning BFM off, and the
+  caveat that an edge Cache Rule on `/file/*` would under-count the
+  per-dataset `Hit` counter. Removed the previous (incorrect)
+  recommendation to use a WAF Custom Rule with
+  `Skip → "Bot Fight Mode"` on Free, and qualified the
+  `/admin/*` recommendations to no longer suggest enabling BFM.
+- No code, dependency, settings, CI, or deploy script changes — this
+  is a documentation-only release that records the operational state
+  of the Cloudflare zone after issue #95 was resolved.
+
 ## v1.7.0
 
 Feature for issue #92 — the homepage table (and the per-tag filter view at

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -87,26 +87,67 @@ In the Cloudflare dashboard for `openmv.net`:
 1. **Security → WAF → Custom rules** → "Create rule":
    - Field: `URI Path`, Operator: `starts with`, Value: `/admin/`
    - Action: `Managed Challenge`
-2. **Security → Bots** → enable "Bot Fight Mode" (free tier is sufficient).
-3. **Caching → Page Rules** → "URL: `*openmv.net/admin/*`" → Cache Level: Bypass.
+2. **Caching → Page Rules** → "URL: `*openmv.net/admin/*`" → Cache Level: Bypass.
+
+(Earlier revisions of this doc also recommended enabling Bot Fight Mode
+here, but BFM has been left **off** site-wide — see the next subsection
+for why.)
 
 `test.openmv.net` is DNS-only (grey cloud) so these rules don't apply
 there — Caddy is the only filter for staging.
 
 #### Bot Fight Mode and dataset downloads
 
-Bot Fight Mode flags non-browser User-Agents (`Python-urllib/3.X`,
-`python-requests/...`, etc.) and can return 403 to legitimate Python
-clients hitting dataset URLs (issue #86). Until v1.6.4 the public
-download path also redirected through `/media/datasets/...`, so a
-single `pandas.read_csv("https://openmv.net/file/<slug>.csv")` was
-evaluated by Cloudflare twice on two different paths. Since v1.6.4
-the `/file/*` view streams the bytes directly via `FileResponse`, so
-only `/file/*` is in the path of legitimate Python downloads. If Bot
-Fight Mode starts blocking that surface too, add a Custom Rule with
-**Field**: `URI Path`, **Operator**: `starts with`, **Value**:
-`/file/`, **Action**: `Skip` → "All remaining custom rules" + "Bot
-Fight Mode".
+Bot Fight Mode (BFM) flags non-browser User-Agents (`Python-urllib/3.X`,
+`python-requests/...`, etc.) from datacenter ASNs and returns 403 to
+legitimate Python clients hitting dataset URLs (issues #86, #95). Until
+v1.6.4 the public download path also redirected through
+`/media/datasets/...`, so a single
+`pandas.read_csv("https://openmv.net/file/<slug>.csv")` was evaluated by
+Cloudflare twice on two different paths; since v1.6.4 the `/file/*` view
+streams the bytes directly via `FileResponse`, so only `/file/*` is in
+the path of legitimate Python downloads.
+
+That origin-side change wasn't enough on its own — BFM still 403'd
+`pandas.read_csv` from AWS hosts and CI runners (issue #95). The
+**current production configuration** is two pure-Cloudflare changes:
+
+1. **Security → Bots → Bot Fight Mode → Off** (site-wide). On the Free
+   plan, BFM is on/off site-wide and **cannot** be skipped per-path by
+   WAF Custom Rules or Configuration Rules — the
+   "Skip → Bot Fight Mode" action only applies to **Super** Bot Fight
+   Mode (Pro+). For a public read-only dataset catalogue with no login
+   or write surface, BFM's protection is marginal compared with the
+   cost of silently breaking every `pd.read_csv` call from a CI
+   pipeline, so it is left off. If the zone is ever upgraded to Pro,
+   replace this with a WAF Custom Rule that `Skip`s
+   "All Super Bot Fight Mode rules" on `URI Path starts_with /file/`.
+2. **Rules → Overview → Configuration Rules → Create rule**:
+   - **When**: `(starts_with(http.request.uri.path, "/file/"))`
+   - **Then**: `Browser Integrity Check → Off`
+   - (The legacy `Security Level → Essentially Off` setting is no
+     longer surfaced in the Configuration Rule editor — Cloudflare
+     retired the per-zone Security Level dial in late 2024, so don't
+     go looking for it.)
+
+Verify from a datacenter IP (an AWS box, a GitHub Actions runner) with:
+
+```bash
+curl -sS -D - -A 'Python-urllib/3.12' -o /dev/null https://openmv.net/file/ammonia.csv
+```
+
+Expect `HTTP/2 200`. The same two-step configuration is what closed
+issue #95.
+
+**Trade-offs to know**: turning BFM off lets all UAs reach origin, so
+log volume on `/file/*` rises. Caddy + gunicorn handle this fine
+today; if it ever becomes a problem, an edge **Cache Rule** on
+`URI Path starts_with /file/` (Edge TTL 1 day) would absorb most of
+the traffic. The cost is that cache hits don't reach Django, so the
+per-dataset `Hit` counter that powers the homepage `Downloads` column
+and the detail-page sparkline (`_annotate_with_downloads` and
+`_download_series` in `datasetapp/views.py`) would under-count by the
+edge hit rate. Keep that in mind before adding the cache rule.
 
 ### fail2ban jail (alternative to caddy-ratelimit)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.7.0"
+version = "1.7.1"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Docs-only patch closing #95. The v1.6.4 origin-side fix (`FileResponse` on `/file/*` instead of redirecting to `/media/*`) was necessary but not sufficient — Cloudflare's **Bot Fight Mode** continued to 403 the `Python-urllib/*` User-Agent from datacenter ASNs (AWS, GitHub Actions runners) even after the redirect went away.

The actual cure turned out to be two pure-Cloudflare configuration changes, no code change and no client-side workaround:

1. **Security → Bots → Bot Fight Mode → Off** (site-wide). On the Free plan, BFM is on/off site-wide — it **cannot** be skipped per-path by WAF Custom Rules or Configuration Rules. The previous note in `docs/SECURITY.md` recommending `Skip → "Bot Fight Mode"` was incorrect; that action only exempts **Super** BFM (Pro+).
2. **Rules → Configuration Rules**: when `URI Path starts_with /file/`, set **Browser Integrity Check → Off**. (The legacy `Security Level → Essentially Off` toggle is gone — Cloudflare retired the per-zone Security Level dial in late 2024.)

Verified from an AWS host:

```bash
curl -sS -D - -A 'Python-urllib/3.12' -o /dev/null https://openmv.net/file/ammonia.csv
# → HTTP/2 200
python -c 'import pandas as pd; pd.read_csv("https://openmv.net/file/ammonia.csv").shape'
# → works
```

### Changes

- **`docs/SECURITY.md`**: rewrote the "Bot Fight Mode and dataset downloads" subsection to record the production Cloudflare configuration, the verification curl, the trade-offs (logs ↑ on `/file/*` since all UAs reach origin; an edge Cache Rule would absorb that but under-count the `Hit` counter), and the upgrade path if the zone ever moves to Pro. Qualified the earlier `/admin/*` recommendation that previously said to enable BFM.
- **`pyproject.toml`** + **`RELEASES.md`**: bump to **v1.7.1** (PATCH — docs-only, no behaviour change) with a release note.

No code, dependency, settings, CI, or deploy script changes.

## Test plan

- [x] `pre-commit run --all-files` (no Python touched, but the markdown / yaml hooks still run cleanly)
- [x] `git diff master -- pyproject.toml` shows only the version bump
- [x] `RELEASES.md` has a `## v1.7.1` heading so the release workflow won't refuse the tag
- [x] Manual verification on production: `curl -A 'Python-urllib/3.12' https://openmv.net/file/ammonia.csv` returns 200; `pandas.read_csv(...)` works from the AWS host that originally reported the bug.

Closes #95.

https://claude.ai/code/session_019zGUVNWnZXiuoeXpZhDhx9

---
_Generated by [Claude Code](https://claude.ai/code/session_019zGUVNWnZXiuoeXpZhDhx9)_