### PR TITLE
v1.8.2: pin compose project name to prevent stack collision

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,36 @@
 # Releases
 
+## v1.8.2
+
+Operational fix: pin the compose project name so the openmv stack
+isn't accidentally torn down by sibling stacks on the same Hetzner VPS.
+
+The literature.learnche.org stack lives at
+`/home/deploy/literature/repo/` and the openmv stack lives at
+`/home/deploy/openmv/repo/` — both checkout directories end in `repo/`,
+so without an explicit `name:` key in the compose files Compose
+defaults the project name to the parent directory's basename and
+both stacks resolve to project=`repo`. That made
+`docker compose -f docker-compose.prod.yml down` in *either* repo
+remove the *other* stack's containers (`openmv-app` +
+`openmv-postgres` were observed disappearing while operating on the
+literature stack).
+
+- **`docker-compose.yml`**, **`docker-compose.prod.yml`**: add a
+  top-level `name: openmv` directive (with a comment explaining the
+  collision the directive prevents). Scopes every Compose
+  invocation in this repo to the openmv project.
+- The companion fix lives in
+  `kgdunn/Django-app-Literature-database` (`name: literature` in its
+  two compose files); the two PRs together fully decouple the
+  stacks' teardown scopes.
+- No runtime behaviour change, no schema change, no template change
+  — `docker compose ps`, `up`, `down`, `restart` all keep working
+  with the existing service names (`web`, `db`) and container
+  names (`openmv-app`, `openmv-postgres`).
+- **`pyproject.toml`** / **`RELEASES.md`**: PATCH bump (operational
+  hygiene, no user-visible change), per the policy in `CLAUDE.md`.
+
 ## v1.8.1
 
 Supply-chain hardening for issues #79 (Issue J) and #77 (Issue H) —

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,6 +9,13 @@
 #   - openmv-app:      127.0.0.1:8001 -> 8000
 #   - openmv-postgres: 127.0.0.1:5434 -> 5432
 
+# Distinct project name keeps `docker compose down` from accidentally
+# tearing out a sibling stack on the same VPS that defaults to the same
+# project (compose's default project name is the parent directory's
+# basename — colocated `/home/deploy/<project>/repo/` checkouts all end
+# in `repo/` and would otherwise share one teardown scope).
+name: openmv
+
 services:
   db:
     # Pinned by digest so a Docker Hub repoint of postgres:16-alpine can't

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,13 @@
 #   docker compose up --build
 # Visit http://127.0.0.1:8080/
 
+# Distinct project name keeps `docker compose down` from accidentally
+# tearing out a sibling stack on the same VPS that defaults to the same
+# project (compose's default project name is the parent directory's
+# basename — colocated `/home/deploy/<project>/repo/` checkouts all end
+# in `repo/` and would otherwise share one teardown scope).
+name: openmv
+
 services:
   web:
     build: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.8.1"
+version = "1.8.2"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "openmv"
-version = "1.8.1"
+version = "1.8.2"
 source = { virtual = "." }
 dependencies = [
     { name = "bleach" },


### PR DESCRIPTION
## Summary

Both `openmv/` and `literature/` on the Hetzner VPS sit at `/home/deploy/<project>/repo/`, so without an explicit `name:` directive in the compose files they default to project name `repo` (compose's default project name is the parent directory's basename). That made `docker compose down` in either repo's directory tear out the *other* stack's containers — observed during literature stack operations: `openmv-app` and `openmv-postgres` were getting wiped.

This PR pins `name: openmv` at the top of both `docker-compose.yml` and `docker-compose.prod.yml` so every compose invocation in this repo is scoped to openmv's containers only.

The companion PR on the literature repo (`kgdunn/Django-app-Literature-database#43`) pins `name: literature` on its two compose files; the two changes are needed together to fully decouple the teardown scopes.

PATCH bump (1.8.1 → 1.8.2) per the versioning policy in `CLAUDE.md` — operational hygiene fix, no runtime behaviour / schema / template change. `pyproject.toml` and `RELEASES.md` updated accordingly.

## Test plan

- [ ] CI green (pre-commit + pytest + pip-audit).
- [ ] On the Hetzner host, after both PRs land: `docker compose -f docker-compose.prod.yml ps` from `/home/deploy/openmv/repo/` lists only `openmv-app` + `openmv-postgres`.
- [ ] `docker compose -f docker-compose.prod.yml down` from `/home/deploy/openmv/repo/` leaves `literature-app` + `literature-postgres` running (and vice versa).
- [ ] `release.yml` workflow auto-tags `v1.8.2` on merge to `master`.

https://claude.ai/code/session_01MincoLXcHKy2Vqmc1GHBo2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MincoLXcHKy2Vqmc1GHBo2)_