### PR TITLE
v1.10.0: download counter shows "since &lt;Mon YYYY&gt;" of earliest hit

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,33 @@
 # Releases
 
+## v1.10.0
+
+Detail-page download counter now reads `<N> downloads since <Mon YYYY>`,
+where the suffix is the month and year of the earliest `Hit` recorded
+for the dataset. The clause is omitted entirely when the dataset has
+never been downloaded — the counter just shows `0 downloads`.
+
+- **`datasetapp/views.py`** — `about_dataset` adds a `first_hit_at`
+  to the template context, sourced from the earliest
+  `Hit.date_and_time` filtered by the whole dataset (across every
+  associated `DataFile`, not just the first one). The query is one
+  extra row read per detail-page request — no aggregate, just an
+  `ORDER BY date_and_time LIMIT 1` against the existing
+  `(dataset_hit, date_and_time)` shape — so it doesn't need its own
+  cache layer the way the sparkline does.
+- **`datasetapp/templates/datasetapp/dataset_info.html`** —
+  `download-meta` paragraph appends `since {{ first_hit_at|date:"M Y" }}`
+  via Django's date filter when `first_hit_at` is truthy. No CSS or
+  layout change.
+- **`datasetapp/tests/test_views.py`** — adds two regressions:
+  `test_about_renders_download_meta_with_first_hit_month` (earliest
+  of two backdated hits drives the suffix) and
+  `test_about_omits_since_clause_when_no_hits` (no hits → no
+  `since` text).
+- **`pyproject.toml`** / **`RELEASES.md`**: MINOR bump per the policy
+  in `CLAUDE.md` (additive change to a public-facing widget; no URL
+  or template-structure break).
+
 ## v1.9.1
 
 Follow-up to v1.9.0: the sparkline now plots the **total** number of

--- a/datasetapp/templates/datasetapp/dataset_info.html
+++ b/datasetapp/templates/datasetapp/dataset_info.html
@@ -27,7 +27,7 @@
             Download <span class="download-cta__type">{{ dfile.file_type }}</span>
         </a>
         <p class="download-hint">(Right-click link; choose "<i>Save Link As</i>")</p>
-        <p class="download-meta">{{ num_hits }} download{{ num_hits|pluralize }}</p>
+        <p class="download-meta">{{ num_hits }} download{{ num_hits|pluralize }}{% if first_hit_at %} since {{ first_hit_at|date:"M Y" }}{% endif %}</p>
 
         {% if num_hits %}
         <div id="downloads-sparkline"></div>

--- a/datasetapp/tests/test_views.py
+++ b/datasetapp/tests/test_views.py
@@ -7,11 +7,13 @@ They deliberately do NOT assert page content beyond status codes — the goal
 is a CI tripwire for accidental view-level breakage, not template coverage.
 """
 
+import datetime
 import json
 from unittest.mock import patch
 
 import pytest
 from django.urls import reverse
+from django.utils import timezone
 
 from datasetapp.models import DataFile, Dataset, Hit, Tag
 
@@ -294,6 +296,35 @@ def test_healthz_does_not_record_a_hit(client, db):
     before = Hit.objects.count()
     client.get(reverse("datasetapp:healthz"))
     assert Hit.objects.count() == before
+
+
+def test_about_renders_download_meta_with_first_hit_month(client, dataset, csv_file):
+    # Two hits on different days; the earliest one drives the "since <Mon YYYY>"
+    # tail on the download counter. ``Hit.date_and_time`` has ``auto_now=True``,
+    # so we have to ``.update()`` the timestamp post-create to keep it from
+    # being clobbered.
+    earliest = timezone.make_aware(datetime.datetime(2020, 2, 14, 12, 0))
+    later = timezone.make_aware(datetime.datetime(2024, 7, 1, 9, 0))
+    h1 = Hit.objects.create(dataset_hit=csv_file)
+    h2 = Hit.objects.create(dataset_hit=csv_file)
+    Hit.objects.filter(pk=h1.pk).update(date_and_time=earliest)
+    Hit.objects.filter(pk=h2.pk).update(date_and_time=later)
+    response = client.get(
+        reverse("datasetapp:dataset-about-a-dataset", args=[dataset.slug])
+    )
+    body = response.content.decode()
+    assert response.status_code == 200
+    assert "2 downloads since Feb 2020" in body
+
+
+def test_about_omits_since_clause_when_no_hits(client, dataset, csv_file):
+    response = client.get(
+        reverse("datasetapp:dataset-about-a-dataset", args=[dataset.slug])
+    )
+    body = response.content.decode()
+    assert response.status_code == 200
+    assert "0 downloads" in body
+    assert "since" not in body.split('class="download-meta"')[1].split("</p>")[0]
 
 
 def test_about_includes_download_series_for_sparkline(client, dataset, csv_file):

--- a/datasetapp/views.py
+++ b/datasetapp/views.py
@@ -250,6 +250,12 @@ def about_dataset(request, dataset_name=None):
         "dfile": dfile,
         "download_file_name": download_file_name,
         "num_hits": Hit.objects.filter(dataset_hit=dfile).count(),
+        "first_hit_at": (
+            Hit.objects.filter(dataset_hit__dataset=ds)
+            .order_by("date_and_time")
+            .values_list("date_and_time", flat=True)
+            .first()
+        ),
         "prev_dataset": prev_dataset,
         "next_dataset": next_dataset,
         "preview_rows": preview_rows,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.9.1"
+version = "1.10.0"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "openmv"
-version = "1.9.1"
+version = "1.10.0"
 source = { virtual = "." }
 dependencies = [
     { name = "bleach" },


### PR DESCRIPTION
## Summary

Detail-page download counter previously read `<N> download(s)` flat. Now it reads e.g. `5061 downloads since Feb 2020` — the suffix is the month + year of the earliest `Hit` recorded for the dataset (across every `DataFile` attached to the dataset). The clause is omitted entirely when the dataset has never been downloaded — the counter just shows `0 downloads`.

- `datasetapp/views.py` — `about_dataset` adds a `first_hit_at` to the template context (`Hit.objects.filter(dataset_hit__dataset=ds).order_by("date_and_time").values_list("date_and_time", flat=True).first()`). One extra `ORDER BY date_and_time LIMIT 1` per detail-page request — no aggregate, so no separate cache layer is warranted.
- `datasetapp/templates/datasetapp/dataset_info.html` — `download-meta` paragraph appends `since {{ first_hit_at|date:"M Y" }}` via the built-in date filter when `first_hit_at` is truthy.
- `datasetapp/tests/test_views.py` — two regressions: `test_about_renders_download_meta_with_first_hit_month` (earliest of two backdated hits drives the suffix; uses `QuerySet.update()` to dodge `auto_now=True`) and `test_about_omits_since_clause_when_no_hits` (no hits → no `since` text).
- `pyproject.toml` / `RELEASES.md` / `uv.lock`: MINOR bump (`1.9.1` → `1.10.0`) per policy — additive change to a public-facing widget; no URL or template-structure break.

## Test plan

- [x] `uv run pytest` — 53 passed
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [ ] Visual check on staging (`test.openmv.net`) once deployed: confirm a popular dataset's detail page reads `<N> downloads since <Mon YYYY>`, and that a freshly added (un-downloaded) dataset reads `0 downloads` with no trailing `since`.

https://claude.ai/code/session_01JQCJpEFGuYiZT5PgDCD6iV

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQCJpEFGuYiZT5PgDCD6iV)_