### PR TITLE
Hero-size the homepage search bar (v1.13.0)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,28 @@
 # Releases
 
+## v1.13.0
+
+Homepage search bar gets a hero variant, matching the sister literature
+site's `.lit-search--hero` proportions: roughly double the regular input
+height (96px), 2rem typography, a larger pill button, and the same
+viewport-aware shrink at 768px / 480px breakpoints. The goal is the same
+as on the literature side — make search the obvious primary action when
+a visitor lands on the dataset list.
+
+- **`datasetapp/templates/datasetapp/base.html`** — add a
+  `.dataset-search--hero` modifier with hero-sized padding, 2rem font,
+  `--radius-lg` corners, `--shadow` elevation, and a matching submit
+  button (96px min-height, 140px min-width). Tablet (≤768px) drops to a
+  ~h3-sized 60px row; phone (≤480px) drops to a touchable 48px row
+  without stacking. The base `.dataset-search` stays unchanged for any
+  future non-hero use.
+- **`datasetapp/templates/datasetapp/all_datasets.html`** — apply the
+  hero modifier (`class="dataset-search dataset-search--hero"`) on the
+  homepage form so the bigger sizing only kicks in on the main visitor
+  entry point.
+
+Pure CSS + a single class addition; no model / view / URL changes.
+
 ## v1.12.0
 
 Visual refresh: swap the teal palette for the sister literature site's

--- a/datasetapp/templates/datasetapp/all_datasets.html
+++ b/datasetapp/templates/datasetapp/all_datasets.html
@@ -12,7 +12,7 @@ Datasets{% endif %}{% endblock %}
     <p>{{current_tag_description}}</p>
 </div>
 {% else %}
-<form class="dataset-search" method="get" role="search" action="{% url 'datasetapp:dataset-home-page' %}">
+<form class="dataset-search dataset-search--hero" method="get" role="search" action="{% url 'datasetapp:dataset-home-page' %}">
     <label for="dataset-search-input" class="visually-hidden">Search datasets</label>
     <input type="search" id="dataset-search-input" name="q" value="{{ query|default:'' }}"
            maxlength="100" placeholder="Search datasets" autocomplete="off">

--- a/datasetapp/templates/datasetapp/base.html
+++ b/datasetapp/templates/datasetapp/base.html
@@ -506,6 +506,62 @@ p  { margin: 0 0 var(--sp-3) 0; }
     font-family: var(--font-mono); font-size: var(--fs-xs);
     color: var(--color-text-subtle);
 }
+
+/* Hero variant — homepage uses this so the primary visitor action
+   (search) is the obvious visual anchor. Mirrors the sister literature
+   site's `.lit-search--hero`. */
+.dataset-search--hero {
+    align-items: stretch;
+    margin: var(--sp-5) 0 var(--sp-3) 0;
+    gap: var(--sp-3);
+}
+.dataset-search--hero input[type="search"] {
+    padding: var(--sp-5) var(--sp-6);
+    font-size: 2rem;
+    line-height: 1.25;
+    border-width: 2px;
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow);
+    min-height: 96px;
+}
+.dataset-search--hero input:focus {
+    box-shadow: 0 0 0 3px var(--color-accent-soft);
+}
+.dataset-search--hero .dataset-search__submit {
+    padding: var(--sp-4) var(--sp-6);
+    font-size: 1.25rem;
+    border-radius: var(--radius-lg);
+    min-width: 140px;
+    min-height: 96px;
+    box-shadow: var(--shadow);
+}
+@media (max-width: 768px) {
+    .dataset-search--hero input[type="search"] {
+        font-size: 1.375rem;
+        padding: var(--sp-3) var(--sp-4);
+        min-height: 60px;
+    }
+    .dataset-search--hero .dataset-search__submit {
+        font-size: 1rem;
+        padding: var(--sp-3) var(--sp-4);
+        min-height: 60px;
+        min-width: 96px;
+    }
+}
+@media (max-width: 480px) {
+    .dataset-search--hero { gap: 8px; }
+    .dataset-search--hero input[type="search"] {
+        font-size: 1.125rem;
+        padding: 10px 12px;
+        min-height: 48px;
+    }
+    .dataset-search--hero .dataset-search__submit {
+        font-size: 0.9375rem;
+        padding: 10px 14px;
+        min-height: 48px;
+        min-width: 80px;
+    }
+}
 .dataset-search__summary {
     margin: 0 0 var(--sp-4) 0;
     color: var(--color-text-muted);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.12.0"
+version = "1.13.0"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "openmv"
-version = "1.12.0"
+version = "1.13.0"
 source = { virtual = "." }
 dependencies = [
     { name = "bleach" },


### PR DESCRIPTION
## Summary
- Add a `.dataset-search--hero` modifier that mirrors the sister literature site's `.lit-search--hero` proportions: ~96px input row, 2rem typography, `--radius-lg` corners, `--shadow` elevation, and a 140×96px pill submit. The base `.dataset-search` stays unchanged for any future non-hero use.
- Apply the modifier on `all_datasets.html` only, so the hero sizing kicks in on the main visitor entry point (the dataset list / search homepage). The tag-filter view keeps the regular sizing.
- Viewport-aware shrink at 768px (→ 60px row) and 480px (→ 48px row) keeps the bar comfortable on tablet / phone without ever stacking input + button.
- Pure CSS + a single class addition. No model / view / URL changes; all 54 tests + the full pre-commit suite pass locally.

## Test plan
- [x] `uv run pytest` — 54 passed
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [ ] Visual smoke on `test.openmv.net` after deploy: confirm the homepage search bar is the obvious primary action at desktop, tablet, and phone widths, in both light and dark modes
- [ ] Confirm the tag-filter view (`/tag/<slug>`) still uses the regular `.detail-topbar` "Back to all datasets" chip and is not affected

https://claude.ai/code/session_01Uz8DZeRNThzKQBDpsMUbEC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uz8DZeRNThzKQBDpsMUbEC)_