### PR TITLE
docs: fix docstrings in slice_string filter and display_by_tag view

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,19 @@
 # Releases
 
+## v1.14.1
+
+Docstring corrections in `datasetapp/`:
+
+- **`datasetapp/templatetags/extra_tags.py`** — the `slice_string`
+  filter's docstring claimed `slice_string:"0:3"` on `'my_long_string'`
+  returned `'my'`, but Python slice semantics actually yield `'my_'`
+  (indices 0, 1, 2). Example corrected and the docstring now states the
+  function delegates to `value[start:end]`.
+- **`datasetapp/views.py`** — `display_by_tag` docstring claimed it
+  filters by an exact tag, but the queryset uses
+  `tags__name__startswith=tag`, so the page lists every dataset whose
+  tag begins with the given prefix. Docstring updated to reflect that.
+
 ## v1.14.0
 
 Rename the `XLS` data-file type to `XLSX` so the catalogue describes the

--- a/datasetapp/templatetags/extra_tags.py
+++ b/datasetapp/templatetags/extra_tags.py
@@ -67,12 +67,13 @@ def sanitise_markup(value):
 def slice_string(value, args):
     """
     Slices a string: returns characters in string, starting with ``start``
-    and ending *one character* before ``end``.
+    and ending *one character* before ``end`` (i.e. Python slice semantics,
+    ``value[start:end]``).
 
     Examples:
-    {{ 'my_long_string' | slice_string:"2" }}  will return '_'
+    {{ 'my_long_string' | slice_string:"2" }}   will return '_'
     {{ 'my_long_string' | slice_string:":2" }}  will return 'my'
-    {{ 'my_long_string' | slice_string:"0:3" }} will return 'my'
+    {{ 'my_long_string' | slice_string:"0:3" }} will return 'my_'
     {{ 'my_long_string' | slice_string:"3:7" }} will return 'long'
     {{ 'my_long_string' | slice_string:"8:" }}    will return 'string'
     {{ 'my_long_string' | slice_string:"8:100" }} will return 'string'

--- a/datasetapp/views.py
+++ b/datasetapp/views.py
@@ -91,7 +91,13 @@ def _annotate_with_downloads(queryset):
 
 def display_by_tag(request, tag):
     """
-    Shows only the datasets with the given tag
+    Shows datasets whose tags start with the given prefix.
+
+    Uses ``tags__name__startswith=tag`` rather than exact matching, so the
+    filter ``tag='python'`` also surfaces datasets tagged 'python-data',
+    'python-science', etc. The page header still resolves ``tag`` against
+    ``Tag.objects.get(name__exact=...)`` for its description, so an exact
+    Tag row with that name must exist.
     """
     log_file.debug("Tag view for tag=%s" % tag)
     dataset_list = _annotate_with_downloads(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.14.0"
+version = "1.14.1"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Two docstring inconsistencies in `datasetapp/`:

- **`slice_string`** (`datasetapp/templatetags/extra_tags.py:67`) - the example claimed `{{ 'my_long_string' | slice_string:"0:3" }}` returned `'my'`, but Python slice semantics (`value[0:3]`) return `'my_'` (indices 0, 1, 2). Example corrected to `'my_'` and the docstring now states that the filter delegates to `value[start:end]` so readers don't trip on the same off-by-one.
- **`display_by_tag`** (`datasetapp/views.py:92`) - docstring said "Shows only the datasets with the given tag", which reads as exact-match. The queryset is `Dataset.objects.filter(tags__name__startswith=tag)`, so `?tag=python` also returns datasets tagged `python-data`, `python-science`, etc. Rewrote to describe the prefix-match behaviour and noted that the page header still resolves the tag against `Tag.objects.get(name__exact=...)` for its description.

Both are documentation-only; no behaviour change. Version bumped to `1.14.1` and `RELEASES.md` updated per `CLAUDE.md`.

## Test plan

- [ ] `uv run pytest` passes.
- [ ] `pre-commit run --all-files` clean.
- [ ] Tag filter pages still render with the corrected description text.


---
_Generated by [Claude Code](https://claude.ai/code/session_011DPDeVfett7hXxgsqqisug)_