### PR TITLE
docs: fix docstring/implementation mismatches

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,19 @@
 # Releases
 
+## v1.14.2
+
+More docstring/comment corrections in the dataset app:
+
+- **`datasetapp/views.py`** — the inline comment above the regex check in
+  `download_dataset` claimed the view rejects anything that isn't
+  "slug+single-dot+3-letter extension", but `_DOWNLOAD_FILENAME_RE` actually
+  accepts a 3- or 4-letter extension since the XLSX rename (v1.14.0 /
+  issue #113). Comment updated to match.
+- **`openmv/urls.py`** — the comment next to the `static()` call still
+  said "Production runs behind Apache, which intercepts /media/ before
+  requests reach Django." The Hetzner cutover moved production to Caddy
+  in May 2026; comment updated.
+
 ## v1.14.1
 
 Docstring corrections in `datasetapp/`:

--- a/datasetapp/views.py
+++ b/datasetapp/views.py
@@ -296,9 +296,10 @@ def download_dataset(request, file_name=None):
     # django-name='dataset-download'
     file_name = (file_name or "").lower()
 
-    # Reject anything that isn't slug+single-dot+3-letter extension up front,
-    # so a stray dot (or no dot at all) returns 404 rather than crashing the
-    # view with a ValueError that surfaces as a 500.
+    # Reject anything that isn't slug+single-dot+3-or-4-letter extension up
+    # front, so a stray dot (or no dot at all) returns 404 rather than
+    # crashing the view with a ValueError that surfaces as a 500. The 4-letter
+    # case is the ``XLSX`` file type added in issue #113.
     if not _DOWNLOAD_FILENAME_RE.match(file_name):
         log_file.warning("Rejected malformed download filename: %r", file_name)
         return HttpResponse("File not found", status=404)

--- a/openmv/urls.py
+++ b/openmv/urls.py
@@ -25,6 +25,6 @@ urlpatterns = [
 ]
 
 # Serve admin-uploaded media via the dev server. Production runs behind
-# Apache, which intercepts /media/ before requests reach Django.
+# Caddy, which serves /media/ from a bind mount before requests reach Django.
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.14.1"
+version = "1.14.2"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Two stale doc-strings/comments in computational + user-facing code, both fixed to match what the implementation actually does. Behaviour-preserving (docs only).

- **`datasetapp/views.py`** — the inline comment above `_DOWNLOAD_FILENAME_RE.match(file_name)` in `download_dataset` said the view rejects anything that isn't `slug+single-dot+3-letter extension`, but the regex (`^[a-z0-9-]+\.[a-z]{3,4}$`) accepts a 3- *or* 4-letter extension since the `XLSX` rename (v1.14.0 / issue #113). Comment updated to match the regex and the canonical description in CLAUDE.md gotcha #5.
- **`openmv/urls.py`** — the comment next to the `if settings.DEBUG: urlpatterns += static(...)` line still said "Production runs behind Apache, which intercepts /media/ before requests reach Django." The Hetzner cutover (May 2026, per CLAUDE.md) moved production to Caddy. Comment updated.

Versioning per CLAUDE.md: PATCH bump (`1.14.1` → `1.14.2`) plus a matching `## v1.14.2` section in `RELEASES.md`.

## Test plan

- [x] `uv run pre-commit run --files datasetapp/views.py openmv/urls.py pyproject.toml RELEASES.md` — passes.
- [x] `SECRET_KEY=test-secret-key uv run pytest` — 57 passed.
- [x] No behaviour changes; CLAUDE.md "Keeping this file consistent" rules re-read — no drift introduced (Project shape / How it runs / Gotchas all already describe the post-fix behaviour, and gotcha #5 already states the 3-or-4-letter regex).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZpPCHdJK5JkYSdxK9WEJv)_