### PR TITLE
Fix docstring/comment inconsistencies in slice_string and download_dataset

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,19 @@
 # Releases
 
+## v1.14.2
+
+Docstring / comment corrections in `datasetapp/`:
+
+- **`datasetapp/templatetags/extra_tags.py`** — the `slice_string`
+  filter returns `False` (a bool) at line 84 when called with
+  `args is None` (i.e. the filter is invoked without an argument),
+  but the docstring only described the happy path. Spell out the
+  edge case so template authors know what to expect.
+- **`datasetapp/views.py`** — the inline comment in `download_dataset`
+  said "slug + single-dot + 3-letter extension", but
+  `_DOWNLOAD_FILENAME_RE` actually accepts a 3-or-4-letter extension
+  (issue #113 added `.xlsx`). Comment updated to match the regex.
+
 ## v1.14.1
 
 Docstring corrections in `datasetapp/`:

--- a/datasetapp/templatetags/extra_tags.py
+++ b/datasetapp/templatetags/extra_tags.py
@@ -70,6 +70,9 @@ def slice_string(value, args):
     and ending *one character* before ``end`` (i.e. Python slice semantics,
     ``value[start:end]``).
 
+    Returns ``False`` when ``args`` is ``None`` (e.g. when the filter is
+    invoked without an argument).
+
     Examples:
     {{ 'my_long_string' | slice_string:"2" }}   will return '_'
     {{ 'my_long_string' | slice_string:":2" }}  will return 'my'

--- a/datasetapp/views.py
+++ b/datasetapp/views.py
@@ -296,7 +296,7 @@ def download_dataset(request, file_name=None):
     # django-name='dataset-download'
     file_name = (file_name or "").lower()
 
-    # Reject anything that isn't slug+single-dot+3-letter extension up front,
+    # Reject anything that isn't slug+single-dot+3-or-4-letter extension up front,
     # so a stray dot (or no dot at all) returns 404 rather than crashing the
     # view with a ValueError that surfaces as a 500.
     if not _DOWNLOAD_FILENAME_RE.match(file_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmv"
-version = "1.14.1"
+version = "1.14.2"
 description = "The Django site behind https://openmv.net — a public catalogue of small, real-world datasets."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Two small docstring/comment corrections in `datasetapp/`:

1. **`datasetapp/templatetags/extra_tags.py`** — the `slice_string` filter's
   docstring only described the "returns characters in string" happy path,
   but at line 84 the function returns `False` (a bool) when called with
   `args is None` (i.e. the filter is invoked without an argument). Note
   added to the docstring so callers know about the edge case.
2. **`datasetapp/views.py`** — the inline comment in `download_dataset`
   said "slug + single-dot + **3-letter** extension", but
   `_DOWNLOAD_FILENAME_RE` (line 38) actually accepts a **3-or-4-letter**
   extension (issue #113, which added the `XLSX` file type — see CLAUDE.md
   gotcha #5). Comment updated to match the regex.

No behavioural change. Docstring / comment only.

## Test plan

- [ ] `uv run pytest -q` is green (or the existing CI run on the PR).
- [ ] No source-of-truth drift — `_DOWNLOAD_FILENAME_RE` and the comment
      now agree; `slice_string` docstring now mentions the `None`-arg
      return value.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RzVs8yMardwSpvCnHjTwj5)_